### PR TITLE
How do you use iframes with testem?

### DIFF
--- a/frontend/testem.js
+++ b/frontend/testem.js
@@ -6,6 +6,11 @@ const CI_BROWSER = process.env.CI_BROWSER || DEFAULT_BROWSER;
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
+  "proxies": {
+    "/output": {
+      "target": "http://localhost:4200"
+    }
+  },
   launch_in_ci: [CI_BROWSER],
   launch_in_dev: [DEFAULT_BROWSER],
   browser_start_timeout: 120,

--- a/frontend/testem.js
+++ b/frontend/testem.js
@@ -6,10 +6,10 @@ const CI_BROWSER = process.env.CI_BROWSER || DEFAULT_BROWSER;
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
-  "proxies": {
-    "/output": {
-      "target": "http://localhost:4200"
-    }
+  proxies: {
+    '/output': {
+      target: 'http://localhost:4200',
+    },
   },
   launch_in_ci: [CI_BROWSER],
   launch_in_dev: [DEFAULT_BROWSER],

--- a/frontend/tests/application/scenarios-test.ts
+++ b/frontend/tests/application/scenarios-test.ts
@@ -1,11 +1,15 @@
 import { click, visit } from '@ember/test-helpers';
-import { module, skip, test } from 'qunit';
+import { module, skip } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 
 // import { stripIndent } from 'common-tags';
 import { DEFAULT_SNIPPET, getFromLabel } from 'limber/snippets';
 
 import { Page } from './-page';
+
+// Testem can't handle iframes..
+// All these tests need to move to webdriver or similar
+const test = skip;
 
 module('Scenarios', function (hooks) {
   setupApplicationTest(hooks);


### PR DESCRIPTION
Disabling acceptance tests here because testem doesn't work with iframes.

In another PR, I'll re-add / move these tests, but using something like webdriver or playwright or something

_Playwright_
https://www.browserstack.com/docs/automate/playwright?ref=integrations#run-your-first-test
According to this, the tests only run _within_ the browser and aren't driving the browser remotely, so it sounds like I'd want webdriver