### PR TITLE
fix: nav select height for safari

### DIFF
--- a/apps/tutorial/app/components/selection.gts
+++ b/apps/tutorial/app/components/selection.gts
@@ -53,7 +53,7 @@ export class Selection extends Component {
 
       <select
         name="tutorial"
-        class="bg-none border border-gray-900 font-lg rounded p-2 w-full indent-[-100000px]"
+        class="bg-none border border-gray-900 font-lg rounded p-2 w-full h-full indent-[-100000px]"
         {{on "change" this.handleChange}}
       >
         {{#each-in this.docs.grouped as |group tutorials|}}


### PR DESCRIPTION
Not a huge deal, but might be helpful for a small subset of users. I've been on safari lately so I noticed the text of the nav was blowing out of the select container.

### BEFORE: 

![Screenshot 2023-03-26 at 7 40 02 AM](https://user-images.githubusercontent.com/6305935/227773367-2b86000a-564a-4c69-a303-b27159baefa3.png)

### AFTER: 

![Screenshot 2023-03-26 at 7 40 13 AM](https://user-images.githubusercontent.com/6305935/227773371-e8d11648-2491-47e0-bdd3-688e9f27d162.png)

### NOTE THIS DOESN'T AFFECT OTHER BROWSERS:

#### Chrome/Brave:
![Screenshot 2023-03-26 at 7 41 06 AM](https://user-images.githubusercontent.com/6305935/227773498-e5874091-4cd4-4c83-afdf-31ef10c6a4fa.png)

#### Firefox:

![Screenshot 2023-03-26 at 7 44 41 AM](https://user-images.githubusercontent.com/6305935/227773504-ef25c907-f3f9-488b-9097-e199abb7272f.png)
