### PR TITLE
fix empty component template  error

### DIFF
--- a/packages/ember-repl/addon/cjs/eti/preprocess.ts
+++ b/packages/ember-repl/addon/cjs/eti/preprocess.ts
@@ -201,6 +201,8 @@ export function preprocessEmbeddedTemplates(
 }
 
 function ensureBackticksEscaped(s: MagicString, start: number, end: number) {
+  if(start >= end) return;
+
   let content = s.slice(start, end);
 
   content = content.replace(/(?<!\\)`/g, '\\`');


### PR DESCRIPTION
when we have an empty template the compiler is throwing an error, this error is caused by calling `override` function of `magic-string`  with wrong arguments, i believe that checking that `start` is always below `end` will prevent  the error from happening 

An example of an empty template: `<template></template> `