### PR TITLE
Try out https://github.com/NullVoxPopuli/action-setup-pnpm/pull/7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       uses: felixmosh/turborepo-gh-artifacts@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: NullVoxPopuli/action-setup-pnpm@v2.0.0
+    - uses: NullVoxPopuli/action-setup-pnpm@NullVoxPopuli-patch-1
     - run:  echo ${{ github.event.number }} > ./pr-number.txt
     - run: pnpm turbo build
     # Used for faster deploy so we don't need to checkout the repo
@@ -69,7 +69,7 @@ jobs:
         uses: felixmosh/turborepo-gh-artifacts@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: NullVoxPopuli/action-setup-pnpm@v2.0.0
+      - uses: NullVoxPopuli/action-setup-pnpm@NullVoxPopuli-patch-1
       - run: pnpm lint
 
 ##############################################################
@@ -94,7 +94,7 @@ jobs:
       uses: felixmosh/turborepo-gh-artifacts@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: NullVoxPopuli/action-setup-pnpm@v2.0.0
+    - uses: NullVoxPopuli/action-setup-pnpm@NullVoxPopuli-patch-1
     - name: Environment Info
       run: |
         firefox --version
@@ -120,7 +120,7 @@ jobs:
   #     uses: felixmosh/turborepo-gh-artifacts@v2
   #     with:
   #       repo-token: ${{ secrets.GITHUB_TOKEN }}
-  #   - uses: NullVoxPopuli/action-setup-pnpm@v2.0.0
+  #   - uses: NullVoxPopuli/action-setup-pnpm@NullVoxPopuli-patch-1
   #   - name: Test
   #     run: pnpm turbo test:scenarios
 
@@ -137,7 +137,7 @@ jobs:
       uses: felixmosh/turborepo-gh-artifacts@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: NullVoxPopuli/action-setup-pnpm@v2.0.0
+    - uses: NullVoxPopuli/action-setup-pnpm@NullVoxPopuli-patch-1
     - run: pnpm turbo test:browserstack --output-logs errors-only
       env:
         # This is a guest user on an open source plan.
@@ -219,6 +219,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       uses: felixmosh/turborepo-gh-artifacts@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: NullVoxPopuli/action-setup-pnpm@support-specifying-package-manager-and-volta.pnpm
+    - uses: NullVoxPopuli/action-setup-pnpm@support-specifying-package-manager-and-volta
     - run:  echo ${{ github.event.number }} > ./pr-number.txt
     - run: pnpm turbo build
     # Used for faster deploy so we don't need to checkout the repo
@@ -69,7 +69,7 @@ jobs:
         uses: felixmosh/turborepo-gh-artifacts@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: NullVoxPopuli/action-setup-pnpm@support-specifying-package-manager-and-volta.pnpm
+      - uses: NullVoxPopuli/action-setup-pnpm@support-specifying-package-manager-and-volta
       - run: pnpm lint
 
 ##############################################################
@@ -94,7 +94,7 @@ jobs:
       uses: felixmosh/turborepo-gh-artifacts@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: NullVoxPopuli/action-setup-pnpm@support-specifying-package-manager-and-volta.pnpm
+    - uses: NullVoxPopuli/action-setup-pnpm@support-specifying-package-manager-and-volta
     - name: Environment Info
       run: |
         firefox --version
@@ -120,7 +120,7 @@ jobs:
   #     uses: felixmosh/turborepo-gh-artifacts@v2
   #     with:
   #       repo-token: ${{ secrets.GITHUB_TOKEN }}
-  #   - uses: NullVoxPopuli/action-setup-pnpm@support-specifying-package-manager-and-volta.pnpm
+  #   - uses: NullVoxPopuli/action-setup-pnpm@support-specifying-package-manager-and-volta
   #   - name: Test
   #     run: pnpm turbo test:scenarios
 
@@ -137,7 +137,7 @@ jobs:
       uses: felixmosh/turborepo-gh-artifacts@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: NullVoxPopuli/action-setup-pnpm@support-specifying-package-manager-and-volta.pnpm
+    - uses: NullVoxPopuli/action-setup-pnpm@support-specifying-package-manager-and-volta
     - run: pnpm turbo test:browserstack --output-logs errors-only
       env:
         # This is a guest user on an open source plan.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       uses: felixmosh/turborepo-gh-artifacts@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: NullVoxPopuli/action-setup-pnpm@NullVoxPopuli-patch-1
+    - uses: NullVoxPopuli/action-setup-pnpm@support-specifying-package-manager-and-volta.pnpm
     - run:  echo ${{ github.event.number }} > ./pr-number.txt
     - run: pnpm turbo build
     # Used for faster deploy so we don't need to checkout the repo
@@ -69,7 +69,7 @@ jobs:
         uses: felixmosh/turborepo-gh-artifacts@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: NullVoxPopuli/action-setup-pnpm@NullVoxPopuli-patch-1
+      - uses: NullVoxPopuli/action-setup-pnpm@support-specifying-package-manager-and-volta.pnpm
       - run: pnpm lint
 
 ##############################################################
@@ -94,7 +94,7 @@ jobs:
       uses: felixmosh/turborepo-gh-artifacts@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: NullVoxPopuli/action-setup-pnpm@NullVoxPopuli-patch-1
+    - uses: NullVoxPopuli/action-setup-pnpm@support-specifying-package-manager-and-volta.pnpm
     - name: Environment Info
       run: |
         firefox --version
@@ -120,7 +120,7 @@ jobs:
   #     uses: felixmosh/turborepo-gh-artifacts@v2
   #     with:
   #       repo-token: ${{ secrets.GITHUB_TOKEN }}
-  #   - uses: NullVoxPopuli/action-setup-pnpm@NullVoxPopuli-patch-1
+  #   - uses: NullVoxPopuli/action-setup-pnpm@support-specifying-package-manager-and-volta.pnpm
   #   - name: Test
   #     run: pnpm turbo test:scenarios
 
@@ -137,7 +137,7 @@ jobs:
       uses: felixmosh/turborepo-gh-artifacts@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: NullVoxPopuli/action-setup-pnpm@NullVoxPopuli-patch-1
+    - uses: NullVoxPopuli/action-setup-pnpm@support-specifying-package-manager-and-volta.pnpm
     - run: pnpm turbo test:browserstack --output-logs errors-only
       env:
         # This is a guest user on an open source plan.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "prettier-plugin-ember-template-tag": "^0.3.2",
     "turbo": "^1.9.4"
   },
-  "packageManager": "pnpm@8.5.0",
   "pnpm": {
     "patchedDependencies": {
       "@changesets/assemble-release-plan@5.2.3": "patches/@changesets__assemble-release-plan@5.2.3.patch"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "prettier-plugin-ember-template-tag": "^0.3.2",
     "turbo": "^1.9.4"
   },
+  "packageManager": "pnpm@8.4.0",
   "pnpm": {
     "patchedDependencies": {
       "@changesets/assemble-release-plan@5.2.3": "patches/@changesets__assemble-release-plan@5.2.3.patch"


### PR DESCRIPTION
Tests: https://github.com/NullVoxPopuli/action-setup-pnpm/pull/7

Pay extra attention to the `Setup` job times
- Without deployment:
    Run 1: 6m16s: https://github.com/NullVoxPopuli/limber/actions/runs/4962686499/usage
    Run 2: 4m13s: https://github.com/NullVoxPopuli/limber/actions/runs/4962729001/usage
    `pnpm` version: https://github.com/NullVoxPopuli/limber/actions/runs/4962686499/jobs/8881064537#step:5:25
does not match `volta.pnpm`, but instead matches `packageManager` ... which does make sense but it's not how volta works locally.

- deleting the `packageManager` entry in package.json:
    `volta.pnpm` still not respected: https://github.com/NullVoxPopuli/limber/actions/runs/4962771802/jobs/8881253890?pr=905#step:5:25

- Bringing `packageManager` entry back, but setting it to an old version of pnpm:
   `packageManager` is not respected either: https://github.com/NullVoxPopuli/limber/actions/runs/4962873854/jobs/8881477973#step:5:25
   
   
Conclusion: action-setup-pnpm only supports latest pnpm by default.
It should probably be a bug fix to add support for checking `volta.pnpm` and then `packageManager`   
