### PR TITLE
Demo of issue#4983 reported to turborepo

### DIFF
--- a/packages/ember-repl/addon/package.json
+++ b/packages/ember-repl/addon/package.json
@@ -35,16 +35,7 @@
   ],
   "scripts": {
     "build": "rollup --config",
-    "lint:types": "glint",
-    "lint:fix": "pnpm -w exec lint fix",
-    "start": "rollup --config --watch",
-    "lint": "pnpm -w exec lint",
-    "lint:js": "pnpm -w exec lint js",
-    "lint:js:fix": "pnpm -w exec lint js:fix",
-    "lint:hbs": "pnpm -w exec lint hbs",
-    "lint:hbs:fix": "pnpm -w exec lint hbs:fix",
-    "lint:prettier:fix": "pnpm -w exec lint prettier:fix",
-    "lint:prettier": "pnpm -w exec lint prettier"
+    "start": "rollup --config --watch"
   },
   "dependencies": {
     "@babel/helper-plugin-utils": "^7.21.5",

--- a/turbo.json
+++ b/turbo.json
@@ -35,13 +35,9 @@
     //
     /////////////////////////////////////////////////
     /////////////////////////////////////////////////
-    "dev": {
-      "dependsOn": ["^dev"],
-      "cache": false
-    },
     "start": {
-      "dependsOn": ["^build"],
-      "cache": false
+      "cache": false,
+      "persistent": true
     },
 
     /////////////////////////////////////////////////
@@ -54,48 +50,6 @@
     "build": {
       "outputs": ["dist/**"],
       "dependsOn": ["^build"]
-    },
-    "test": {
-      "outputs": [],
-      "dependsOn": ["^build"]
-    },
-    // Apps will have test:ember and test:browserstack
-    // They are separate so that they can cache independently
-    // and provide more variability than just "test"
-    "test:ember": {
-      "env": ["CI_BROWSER", "EMBER_TRY_CURRENT_SCENARIO", "EMBROIDER_TEST_SETUP_OPTIONS"],
-      "dependsOn": ["^build"]
-    },
-    "test:browserstack": {
-      "dependsOn": ["^build"]
-    },
-    // All scenarios
-    "test:scenarios": {
-      "dependsOn": ["^build"]
-    },
-
-    /////////////////////////////////////////////////
-    /////////////////////////////////////////////////
-    //
-    //         Quality Checks
-    //
-    /////////////////////////////////////////////////
-    /////////////////////////////////////////////////
-    "_:lint": {
-      "outputs": [],
-      "dependsOn": ["lint:js", "lint:hbs", "lint:prettier", "lint:types"]
-    },
-    "lint:js": { "outputs": [] },
-    "lint:hbs": { "outputs": [] },
-    "lint:prettier": { "outputs": [] },
-    "lint:types": { "outputs": [], "dependsOn": ["^build"] },
-
-    "_:lint:fix": {
-      "cache": false,
-      "dependsOn": ["lint:js:fix", "lint:hbs:fix"]
-    },
-    "lint:js:fix": { "cache": false, "dependsOn": ["lint:prettier:fix"] },
-    "lint:hbs:fix": { "cache": false, "dependsOn": ["lint:prettier:fix"] },
-    "lint:prettier:fix": { "cache": false }
+    }
   }
 }


### PR DESCRIPTION
Reported turbo issue: https://github.com/vercel/turbo/issues/4983

Problem: rollup's watch mode is killed by turbo, or not waited for?, hard to tell.

Reproduction steps:
1. `git clone git@github.com:NullVoxPopuli/limber.git`
2. `cd limber`
3. `git checkout how-to-get-turbo-rollup-watching`
4. `pnpm i --ignore-scripts`
5. observe that in `packages/ember-repl/addon/package.json` the `start` script is `rollup --config --watch`
6. try to start watch mode via turbo: `pnpm turbo start --filter ember-repl`
7. observe that turbo exited, when it should have not-exited due to rollup being in watch mode
8. `cd packages/ember-repl/addon`
9. `pnpm start`
10. observe that the `start` script in this package is a long-running watch mode that doesn't exit unless `Ctrl+C` is pressed (or some other kill/stop process signal is sent to the process)