### PR TITLE
Fix ember-repl publish

### DIFF
--- a/packages/ember-repl/addon/package.json
+++ b/packages/ember-repl/addon/package.json
@@ -60,6 +60,7 @@
     "addon-main.cjs"
   ],
   "scripts": {
+    "prepack": "rollup --config",
     "build": "rollup --config",
     "lint:types": "tsc --noEmit",
     "lint:fix": "pnpm -w exec lint fix",


### PR DESCRIPTION
how did this ever work if there was no prepack script?