### PR TITLE
Update format selection

### DIFF
--- a/apps/repl/app/components/limber/layout/controls/format-menu.gts
+++ b/apps/repl/app/components/limber/layout/controls/format-menu.gts
@@ -3,12 +3,12 @@ import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { service } from '@ember/service';
 
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
-
 import Menu from 'limber/components/limber/menu';
 
 import type RouterService from '@ember/routing/router-service';
 import type { Format } from 'limber/utils/messaging';
+
+const menuIconClasses = `inline-block bg-ember-black text-white text-xs px-1 rounded w-8 text-center`;
 
 export class FormatMenu extends Component<{ Element: HTMLButtonElement }> {
   @service declare router: RouterService;
@@ -17,24 +17,39 @@ export class FormatMenu extends Component<{ Element: HTMLButtonElement }> {
     this.router.transitionTo({ queryParams: { format } });
   };
 
+  // Just text, but could be proper icons
+  iconFor = (format: Format): string => {
+    switch (format) {
+      case 'glimdown':
+        return 'G⬇';
+      case 'gjs':
+        return 'GJS';
+      case 'hbs':
+        return 'HBS';
+    }
+  };
+
   <template>
     <Menu>
       <:trigger as |t|>
         <t.Button title="Change document language" ...attributes>
-          <FaIcon @icon="cog" />
+          {{this.iconFor this.router.currentRoute.queryParams.format}}
         </t.Button>
       </:trigger>
 
       <:options as |Item|>
         <Item {{on "click" (fn this.switch "glimdown")}}>
+          <div class={{menuIconClasses}}>{{this.iconFor "glimdown"}}</div>
           Glimdown
         </Item>
 
         <Item {{on "click" (fn this.switch "gjs")}}>
+          <div class={{menuIconClasses}}>{{this.iconFor "gjs"}}</div>
           Glimmer JS
         </Item>
 
         <Item {{on "click" (fn this.switch "hbs")}}>
+          <div class={{menuIconClasses}}>{{this.iconFor "hbs"}}</div>
           Template
         </Item>
       </:options>


### PR DESCRIPTION
This simple PR updates the format selector menu in two ways:
- replaces the cog icon with the currently selected format
- adds "icons" to the menu

Together, these improve the visibility for the fact that you can change the format.

<img width="275" alt="Screenshot 2024-06-18 at 10 13 20 AM" src="https://github.com/NullVoxPopuli/limber/assets/142243/32e2af29-09ae-42cb-b1eb-76a0f09a7718">
