### PR TITLE
Fixed issue #1792: Used of modifier instead of component.

### DIFF
--- a/apps/tutorial/public/docs/6-partial-application/4-component/prose.md
+++ b/apps/tutorial/public/docs/6-partial-application/4-component/prose.md
@@ -1,4 +1,4 @@
-`component` is used for [partial application][wiki] of arguments to modifiers.
+`component` is used for [partial application][wiki] of arguments to conponents.
 
 This can be useful for pre-wiring arguments to complex components, or components with private implementation details that a consumer may not need to care about.
 


### PR DESCRIPTION
This issue was caused by a mix-up of modifier for component, where modifier was used in the prose title, but in the body it was component. This happened in the explanation of component partial application.

Resolves #1792 

```
component is used for partial application of arguments to modifiers.

This can be useful for pre-wiring arguments to complex components
```

<!-- If this template is unchanged, and GitHub Copilot for Pull Requests is active, a summary and walkthrough will be generated for you -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary 
<!-- cspell:disable-next-line -->
copilot:summary
 
## Details 
<!-- cspell:disable-next-line -->



