### PR TITLE
Rename swapi.dev to swapi.tech

### DIFF
--- a/apps/tutorial/public/docs/8-form-data-controlled/20-dependent-select-dropdowns/answer.gjs
+++ b/apps/tutorial/public/docs/8-form-data-controlled/20-dependent-select-dropdowns/answer.gjs
@@ -40,7 +40,7 @@ function data() {
 }
 
 function urlForDataSource(selectedData) {
-  return `https://swapi.dev/api/${selectedData}/`;
+  return `https://swapi.tech/api/${selectedData}/`;
 }
 
 function setSelected(propertyName, value) {

--- a/apps/tutorial/public/docs/8-form-data-controlled/20-dependent-select-dropdowns/prose.md
+++ b/apps/tutorial/public/docs/8-form-data-controlled/20-dependent-select-dropdowns/prose.md
@@ -5,7 +5,7 @@ should occur automatically based on changes in option selected`.
 
    ```javascript
    function urlForDataSource(selectedData) {
-       return `https://swapi.dev/api/${selectedData}/`;
+       return `https://swapi.tech/api/${selectedData}/`;
    }
    ```
 
@@ -49,4 +49,4 @@ Use conditional rendering to display a loading message while the API call is in 
 Docs for `RemoteData` can [be found here][docs-remote-data].
 
 [docs-remote-data]: https://reactive.nullvoxpopuli.com/functions/remote_data.RemoteData-1.html
-[swapi]: https://swapi.dev/
+[swapi]: https://swapi.tech/


### PR DESCRIPTION
Related to #1709
See commit f504ae7dc3d9fd49a7f4fb035a895a182c87da1d

This MR renames swapi.dev to swapi.tech so tutorial works with no change to the data source URL
