### PR TITLE
Remove unused option block

### DIFF
--- a/apps/tutorial/public/docs/8-form-data-controlled/20-dependent-select-dropdowns/answer.gjs
+++ b/apps/tutorial/public/docs/8-form-data-controlled/20-dependent-select-dropdowns/answer.gjs
@@ -78,11 +78,7 @@ function names(options) {
          <Select
            @options={{names request.value.results}}
            @onChange={{fn setSelected selectedAPI.current}}
-          >
-            <:option as |item|>
-              {{item.name}}
-            </:option>
-         </Select>
+         />
       {{/if}}
     {{/let}}
   </label>

--- a/apps/tutorial/public/docs/8-form-data-controlled/20-dependent-select-dropdowns/prose.md
+++ b/apps/tutorial/public/docs/8-form-data-controlled/20-dependent-select-dropdowns/prose.md
@@ -30,11 +30,7 @@ After fetching the data, you need to update the second dropdown with the results
         <Select 
           @options={{names request.value.results}} 
           @onChange={{(fn setSelected selectedAPI.current)}} 
-        >
-          <:option as |item|>
-            {{item.name}}
-          </:option>
-        </Select>
+        />
     {{/if}}
    {{/let}}
    ```


### PR DESCRIPTION
Simplify and improve readability by removing unused `:option` block

:warning: previewing this branch won't work unless you change `swapi.dev` to `swapi.tech` URL