### PR TITLE
Optimize REPL load

### DIFF
--- a/apps/repl/perf-check.sh
+++ b/apps/repl/perf-check.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+echo "Measuring build perf of $(basename $PWD)"
+
+# Set LOCAL=./to/wherever/you/cloned/the/perf/code/locally
+#
+# Example
+#
+#   LOCAL=~/Development/OpenSource/build-start-rebuild-perf/bin/cli.js ./perf-check.sh
+#
+#   or
+#
+#   Local=1 ./perf-check.sh
+#
+#
+#  (Setting to 1 means use this exact path)
+if [[ -v LOCAL ]]; then
+  if [[ "$LOCAL" == "1" ]]; then
+    relative="Development/OpenSource/build-start-rebuild-perf/bin/cli.js"
+    LOCAL="$HOME/$relative"
+    echo "Using default location of ~/$relative"
+  fi
+
+	node $LOCAL \
+		--file ./app/app.js \
+		--wait-for "main header nav" \
+		--url "https://localhost:4201/" \
+		--log-level log
+else
+	# Docs: https://github.com/mainmatter/build-start-rebuild-perf
+	pnpm dlx build-start-rebuild-perf \
+		--file ./app/app.js \
+		--wait-for "main header nav" \
+		--url "https://localhost:4201/" \
+		--log-level log
+fi

--- a/apps/repl/vite.config.js
+++ b/apps/repl/vite.config.js
@@ -22,6 +22,56 @@ export default defineConfig(() => ({
       'ember-repl',
       'repl-sdk',
     ],
+    // These dependencies are *always*
+    // needed on initial load.
+    // So we can boost initial load perf by eagerly optimizing them instead of waiting for the module graph crawl
+    include: [
+      // Our Runtime
+      '@shikijs/rehype/core',
+      'shiki/core',
+      'shiki/langs/*',
+      'shiki/wasm',
+      'shiki/themes/github-*',
+      // Framework
+      // 'ember-source/@ember/**/*',
+      // Theme and Syntax
+      '@codemirror/language',
+      '@codemirror/view',
+      // REPL + Editor
+      'ember-repl > codemirror',
+      'ember-repl > repl-sdk > codemirror',
+      'ember-repl > repl-sdk > codemirror-lang-mermaid',
+      'ember-repl > repl-sdk > tarparser',
+      'ember-repl > repl-sdk > package-name-regex',
+      'ember-repl > repl-sdk > rehype-raw',
+      'ember-repl > repl-sdk > rehype-stringify',
+      'ember-repl > repl-sdk > remark-gfm',
+      'ember-repl > repl-sdk > remark-parse',
+      'ember-repl > repl-sdk > remark-rehype',
+      'ember-repl > repl-sdk > unified',
+      'ember-repl > repl-sdk > unist-util-visit',
+      'ember-repl > repl-sdk > change-case',
+      'ember-repl > repl-sdk > @codemirror/autocomplete',
+      'ember-repl > repl-sdk > @codemirror/commands',
+      'ember-repl > repl-sdk > @codemirror/lang-html',
+      'ember-repl > repl-sdk > @codemirror/lang-html > @codemirror/lang-css',
+      'ember-repl > repl-sdk > @codemirror/lang-javascript',
+      'ember-repl > repl-sdk > @codemirror/lang-javascript > @lezer/javascript',
+      'ember-repl > repl-sdk > @codemirror/lang-markdown',
+      'ember-repl > repl-sdk > @codemirror/lang-markdown > @lezer/markdown',
+      'ember-repl > repl-sdk > @codemirror/lang-vue',
+      'ember-repl > repl-sdk > @codemirror/lang-yaml',
+      'ember-repl > repl-sdk > @codemirror/language',
+      'ember-repl > repl-sdk > @codemirror/language > @lezer/common',
+      'ember-repl > repl-sdk > @codemirror/language > @lezer/lr',
+      'ember-repl > repl-sdk > @codemirror/language > @lezer/highlight',
+      'ember-repl > repl-sdk > @codemirror/language-data',
+      'ember-repl > repl-sdk > @codemirror/lint',
+      'ember-repl > repl-sdk > @codemirror/search',
+      'ember-repl > repl-sdk > @codemirror/state',
+      'ember-repl > repl-sdk > @codemirror/view',
+    ],
+
     // for top-level-await, etc
     esbuildOptions: {
       target: 'esnext',

--- a/packages/repl-sdk/package.json
+++ b/packages/repl-sdk/package.json
@@ -50,7 +50,6 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@babel/plugin-proposal-decorators": "^7.28.0",
     "@nullvoxpopuli/eslint-configs": "^5.2.0",
     "@shikijs/rehype": "^3.7.0",
     "@tsconfig/ember": "^3.0.7",

--- a/packages/repl-sdk/vite.config.mts
+++ b/packages/repl-sdk/vite.config.mts
@@ -13,17 +13,17 @@ let manifest = await (async () => {
 })();
 
 let forcedExternals = [
-  "unified",
-  "remark-parse",
-  "remark-rehype",
-  "remark-gfm",
-  "rehype-raw",
-  "rehype-stringify",
-  "mdast",
-  "hast",
-  "unist",
-  "unist-util-visit",
-  "vfile",
+  // "unified",
+  // "remark-parse",
+  // "remark-rehype",
+  // "remark-gfm",
+  // "rehype-raw",
+  // "rehype-stringify",
+  // "mdast",
+  // "hast",
+  // "unist",
+  // "unist-util-visit",
+  // "vfile",
 ];
 
 let externals = [
@@ -32,7 +32,9 @@ let externals = [
     ...(manifest.peerDependencies || {}),
   }),
   ...forcedExternals,
-];
+].filter((x) => {
+  return !x.includes("codemirror");
+});
 
 export default defineConfig({
   build: {
@@ -50,11 +52,9 @@ export default defineConfig({
     sourcemap: true,
     lib: {
       // Could also be a dictionary or array of multiple entry points
-      entry: resolve(__dirname, "src/index.js"),
+      entry: [resolve(__dirname, "src/index.js")],
       name: "repl-sdk",
       formats: ["es"],
-      // the proper extensions will be added
-      fileName: "index",
     },
     rollupOptions: {
       external: externals,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1231,9 +1231,6 @@ importers:
         specifier: ^0.0.5
         version: 0.0.5
     devDependencies:
-      '@babel/plugin-proposal-decorators':
-        specifier: ^7.28.0
-        version: 7.28.0(@babel/core@7.28.0)
       '@nullvoxpopuli/eslint-configs':
         specifier: ^5.2.0
         version: 5.2.1(4279a8ab52cb9c60baa54b0d1cf65c63)
@@ -11112,8 +11109,8 @@ packages:
       '@volar/language-service':
         optional: true
 
-  volar-service-typescript@0.0.64:
-    resolution: {integrity: sha512-FN2H97iqjR1id8AM4fH7lTXuTx2on9zD6QlUFllaiHKqgNrEITlQwm/9Ujrd9ST7MUzhgIKyUsa2WlanX9kkMg==}
+  volar-service-typescript@0.0.65:
+    resolution: {integrity: sha512-zPJuLIMs7lkQCvL+Rza8+3/EIoXEIkX8+DL7bNNfPgnbalbvRDhqWLVMJ6Zk3pINjLJafDqyhSbw8srfkUv97w==}
     peerDependencies:
       '@volar/language-service': ~2.4.0
     peerDependenciesMeta:
@@ -13462,7 +13459,7 @@ snapshots:
       typescript: 5.8.3
       uuid: 8.3.2
       volar-service-html: 0.0.64(@volar/language-service@2.4.12)
-      volar-service-typescript: 0.0.64(@volar/language-service@2.4.12)
+      volar-service-typescript: 0.0.65(@volar/language-service@2.4.12)
       vscode-languageserver-protocol: 3.17.5
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
@@ -23073,7 +23070,7 @@ snapshots:
     optionalDependencies:
       '@volar/language-service': 2.4.12
 
-  volar-service-typescript@0.0.64(@volar/language-service@2.4.12):
+  volar-service-typescript@0.0.65(@volar/language-service@2.4.12):
     dependencies:
       path-browserify: 1.0.1
       semver: 7.7.2


### PR DESCRIPTION
Adds perf-check.sh, and I have these results atm:
```
| Dev Server Ready | First Paint | App Loaded |
| ---------------- | ----------- | ---------- |
| 842 ms           | 5,766 ms    | 7,879 ms   |
```

This is good because when I was on embroider-webpack initial load / time to first paint was closer to 25/30s.

Before customizing the optimizeDeps config, these were my results
```
| Dev Server Ready | First Paint | App Loaded |
| ---------------- | ----------- | ---------- |
| 989 ms           | 14,481 ms   | 32,307 ms  |
```

The subsequent reloads due to lazy depOptimization for the default path were silly.