### PR TITLE
Markdown deps are bundled, don't define imports for them in ember-repl

### DIFF
--- a/packages/ember-repl/src/services/known-modules.ts
+++ b/packages/ember-repl/src/services/known-modules.ts
@@ -6,8 +6,7 @@ const frameworkModules = {
   '@ember/array': () => import('@ember/array'),
   '@ember/component': () => import('@ember/component'),
   '@ember/component/helper': () => import('@ember/component/helper'),
-  '@ember/component/template-only': () =>
-    import('@ember/component/template-only'),
+  '@ember/component/template-only': () => import('@ember/component/template-only'),
   '@ember/debug': () => import('@ember/debug'),
   '@ember/destroyable': () => import('@ember/destroyable'),
   '@ember/helper': () => import('@ember/helper'),
@@ -33,8 +32,7 @@ const frameworkModules = {
   '@ember/version': () => import('@ember/version'),
   '@glimmer/component': () => import('@glimmer/component'),
   '@glimmer/tracking': () => import('@glimmer/tracking'),
-  '@glimmer/tracking/primitives/cache': () =>
-    import('@glimmer/tracking/primitives/cache'),
+  '@glimmer/tracking/primitives/cache': () => import('@glimmer/tracking/primitives/cache'),
 };
 
 const coreLibraries = {
@@ -45,16 +43,17 @@ const coreLibraries = {
 };
 
 const emberCompilationModules = {
-  '@ember/template-compiler/runtime': () =>
-    import('@ember/template-compiler/runtime'),
+  '@ember/template-compiler/runtime': () => import('@ember/template-compiler/runtime'),
   '@ember/template-compiler': () => import('@ember/template-compiler/runtime'),
   'ember-source/dist/ember-template-compiler': () =>
     import(
+       
       // @ts-ignore
       'ember-source/dist/ember-template-compiler.js'
     ),
   'ember-source/dist/ember-template-compiler.js': () =>
     import(
+       
       // @ts-ignore
       'ember-source/dist/ember-template-compiler.js'
     ),
@@ -67,7 +66,7 @@ const emberCompilationModules = {
     import('babel-plugin-ember-template-compilation'),
   // Dependencies of the above
   'babel-import-util': () => import('babel-import-util'),
-
+   
   // @ts-ignore
   'babel-plugin-debug-macros': () => import('babel-plugin-debug-macros'),
   '@embroider/macros': () => ({
@@ -102,10 +101,9 @@ const emberCompilationModules = {
       },
     }),
     // Private
-
+     
     // @ts-ignore
-    importSync: (x: string) =>
-      window[Symbol.for('__repl-sdk__compiler__')].resolves[x],
+    importSync: (x: string) => window[Symbol.for('__repl-sdk__compiler__')].resolves[x],
     moduleExists: () => false,
   }),
 };


### PR DESCRIPTION
<!-- 
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

  Explain the **motivation** for making this change. 

  What existing problem does the pull request solve? 

-->
