### PR TITLE
fix: dom event correctly references first example

### DIFF
--- a/apps/tutorial/public/docs/3-event-handling/1-dom-events/prose.md
+++ b/apps/tutorial/public/docs/3-event-handling/1-dom-events/prose.md
@@ -1,4 +1,4 @@
-As seen previously, `on` was used to listen for `click` events on a button.
+As seen previously, `on` was used to listen for `input` events on an input.
 
 The `on` modifier can be thought of as an alias for [`addEventListener`][mdn-addEventListener], so anything it can do, `on` can do.
 


### PR DESCRIPTION
First example of on was used for input event https://tutorial.glimdown.com/2-reactivity/8-components not a button event

