### PR TITLE
Upgrade vite-ember-ssr to 0.1.0-alpha.9, remove redundant noExternal

### DIFF
--- a/apps/repl/package.json
+++ b/apps/repl/package.json
@@ -111,7 +111,7 @@
     "vfile": "^6.0.3",
     "vite": "8.0.0-beta.7",
     "vite-bundle-analyzer": "^1.3.1",
-    "vite-ember-ssr": "0.1.0-alpha.8",
+    "vite-ember-ssr": "0.1.0-alpha.9",
     "vite-plugin-circular-dependency": "^0.5.0",
     "vite-plugin-mkcert": "^1.17.9",
     "zimmerframe": "^1.1.4"

--- a/apps/repl/vite.config.js
+++ b/apps/repl/vite.config.js
@@ -295,8 +295,5 @@ export default defineConfig((env) => {
         rehydrate: true,
       }),
     ].flat(),
-    ssr: {
-      noExternal: [/./],
-    },
   };
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,8 +432,8 @@ importers:
         specifier: ^1.3.1
         version: 1.3.2
       vite-ember-ssr:
-        specifier: 0.1.0-alpha.8
-        version: 0.1.0-alpha.8(d4b8df0a12ed95f9116be3f7aceb82ff)
+        specifier: 0.1.0-alpha.9
+        version: 0.1.0-alpha.9(d4b8df0a12ed95f9116be3f7aceb82ff)
       vite-plugin-circular-dependency:
         specifier: ^0.5.0
         version: 0.5.0(rollup@4.57.1)
@@ -11212,8 +11212,8 @@ packages:
     resolution: {integrity: sha512-Od4ILUKRvBV3LuO/E+S+c1XULlxdkRZPSf6Vzzu+UAXG0D3hZYUu9imZIkSj/PU4e1FB14yB+av8g3KiljH8zQ==}
     hasBin: true
 
-  vite-ember-ssr@0.1.0-alpha.8:
-    resolution: {integrity: sha512-XvyDn8TdJpncU8ZDyp3jlzkNfXiZ6X79w89YRp6DD2wRB9/Xl8EKDnRf79jzU2A9SnlAiJeazLqD595RK34Kqw==}
+  vite-ember-ssr@0.1.0-alpha.9:
+    resolution: {integrity: sha512-ZSvOMJUP46SQyCKvuK/wGxnUhVFCKkiaZd7z/pN8sMPePGBo7oTr/UJlkDojkGmKwIumIekfiBcOwNE0qxYlIQ==}
     engines: {node: '>=22'}
     peerDependencies:
       vite: ^6.0.0 || ^7.0.0
@@ -22860,7 +22860,7 @@ snapshots:
 
   vite-bundle-analyzer@1.3.2: {}
 
-  vite-ember-ssr@0.1.0-alpha.8(d4b8df0a12ed95f9116be3f7aceb82ff):
+  vite-ember-ssr@0.1.0-alpha.9(d4b8df0a12ed95f9116be3f7aceb82ff):
     dependencies:
       happy-dom: 20.8.9
       vite: 8.0.0-beta.7(91ea72be1d635d3ef7526fc034504da7)


### PR DESCRIPTION
## Summary

- Upgrades `vite-ember-ssr` from `0.1.0-alpha.8` to `0.1.0-alpha.9`
- Removes the manual `ssr: { noExternal: [/./] }` from `vite.config.js` — the plugin now sets this internally via its `bundleAllDeps()` function ([evoactivity/vite-ember-ssr#4](https://github.com/evoactivity/vite-ember-ssr/commit/46fb3286ec))

## Test plan

- [ ] Verify SSG build still works (`pnpm build` in apps/repl)
- [ ] Verify docs pages are pre-rendered correctly
- [ ] Verify client-side rehydration works on doc routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)