### PR TITLE
Restore args forwarding to the rendered component in ember-repl

### DIFF
--- a/packages/ember-repl/src/compile/Compiled.ts
+++ b/packages/ember-repl/src/compile/Compiled.ts
@@ -9,6 +9,8 @@ import type { CompileState } from './state.ts';
 import type { Format, Input } from './types.ts';
 
 export interface CompiledOptions {
+  format?: Format;
+  flavor?: string;
   /**
    * Arguments forwarded to the compiled component.
    *
@@ -26,6 +28,10 @@ export interface CompiledOptions {
 export function Compiled(markdownText: Input | (() => Input)): CompileState;
 export function Compiled(
   markdownText: Input | (() => Input),
+  options: CompiledOptions
+): CompileState;
+export function Compiled(
+  markdownText: Input | (() => Input),
   format?: Format,
   flavor?: string
 ): CompileState;
@@ -38,40 +44,48 @@ export function Compiled(
   format: () => Format,
   flavor: () => string
 ): CompileState;
-export function Compiled(
-  markdownText: Input | (() => Input),
-  format?: Format | (() => Format),
-  flavor?: string | (() => string),
-  options?: CompiledOptions
-): CompileState;
 
 /**
  * By default, this compiles to `glimdown`. A Markdown format which
  * extracts `live` tagged code snippets and compiles them to components.
  *
- * The optional fourth argument may specify `args` to forward to the
- * compiled component — see `CompiledOptions`.
+ * Pass a `CompiledOptions` bag as the second argument to specify
+ * `format`, `flavor`, and `args` forwarded to the rendered component.
  */
 export function Compiled(
   markdownText: Input | (() => Input),
-  maybeFormat?: Format | (() => Format),
-  maybeFlavor?: string | (() => string),
-  maybeOptions?: CompiledOptions
+  maybeFormatOrOptions?: Format | (() => Format) | CompiledOptions,
+  maybeFlavor?: string | (() => string)
 ): CompileState {
   return resource(({ owner }) => {
     const input =
       typeof markdownText === 'function' ? markdownText() : markdownText;
-    const format =
-      typeof maybeFormat === 'function'
-        ? maybeFormat()
-        : maybeFormat || 'glimdown';
-    let flavor =
-      typeof maybeFlavor === 'function' ? maybeFlavor() : maybeFlavor;
 
-    flavor = typeof flavor === 'string' ? flavor : undefined;
+    let format: Format | undefined;
+    let flavor: string | undefined;
+    let args: Record<string, unknown> | undefined;
+
+    if (typeof maybeFormatOrOptions === 'function') {
+      format = maybeFormatOrOptions();
+    } else if (typeof maybeFormatOrOptions === 'string') {
+      format = maybeFormatOrOptions;
+    } else if (maybeFormatOrOptions) {
+      format = maybeFormatOrOptions.format;
+      flavor = maybeFormatOrOptions.flavor;
+      args = maybeFormatOrOptions.args;
+    }
+
+    format ??= 'glimdown';
+
+    if (flavor === undefined) {
+      const positional =
+        typeof maybeFlavor === 'function' ? maybeFlavor() : maybeFlavor;
+
+      flavor = typeof positional === 'string' ? positional : undefined;
+    }
 
     assert(
-      `second parameter to Compiled must be a format or function that returns a format`,
+      `second parameter to Compiled must be a format, an options bag, or a function that returns a format`,
       typeof format === 'string'
     );
 
@@ -80,7 +94,7 @@ export function Compiled(
     return compile(compiler, input, {
       format,
       flavor,
-      args: maybeOptions?.args,
+      args,
     });
   });
 }

--- a/packages/ember-repl/src/compile/Compiled.ts
+++ b/packages/ember-repl/src/compile/Compiled.ts
@@ -8,6 +8,21 @@ import { compile } from './compile.ts';
 import type { CompileState } from './state.ts';
 import type { Format, Input } from './types.ts';
 
+export interface CompiledOptions {
+  /**
+   * Arguments forwarded to the compiled component.
+   *
+   * Pass a stable object reference whose property values are reactive
+   * (e.g. a `TrackedObject` or a plain object with getters reading
+   * `@tracked` state). Property updates propagate to the rendered
+   * component without triggering a recompile.
+   *
+   * Keys must be present when compilation happens — additional keys
+   * added later will not become reactive.
+   */
+  args?: Record<string, unknown>;
+}
+
 export function Compiled(markdownText: Input | (() => Input)): CompileState;
 export function Compiled(
   markdownText: Input | (() => Input),
@@ -23,15 +38,25 @@ export function Compiled(
   format: () => Format,
   flavor: () => string
 ): CompileState;
+export function Compiled(
+  markdownText: Input | (() => Input),
+  format?: Format | (() => Format),
+  flavor?: string | (() => string),
+  options?: CompiledOptions
+): CompileState;
 
 /**
  * By default, this compiles to `glimdown`. A Markdown format which
  * extracts `live` tagged code snippets and compiles them to components.
+ *
+ * The optional fourth argument may specify `args` to forward to the
+ * compiled component — see `CompiledOptions`.
  */
 export function Compiled(
   markdownText: Input | (() => Input),
   maybeFormat?: Format | (() => Format),
-  maybeFlavor?: string | (() => string)
+  maybeFlavor?: string | (() => string),
+  maybeOptions?: CompiledOptions
 ): CompileState {
   return resource(({ owner }) => {
     const input =
@@ -55,6 +80,7 @@ export function Compiled(
     return compile(compiler, input, {
       format,
       flavor,
+      args: maybeOptions?.args,
     });
   });
 }

--- a/packages/ember-repl/src/compile/compile.ts
+++ b/packages/ember-repl/src/compile/compile.ts
@@ -76,7 +76,7 @@ async function runTheCompiler({
   if (options.format === 'glimdown') {
     result = await service.compile('gmd', text, options as any);
   } else if (options.format === 'gjs') {
-    result = await service.compileGJS(text, options as any);
+    result = await service.compileGJS(text, { args: options.args });
   } else if (options.format === 'hbs') {
     result = await service.compileHBS(text, options as any);
   } else {

--- a/packages/ember-repl/src/compile/compile.ts
+++ b/packages/ember-repl/src/compile/compile.ts
@@ -76,7 +76,10 @@ async function runTheCompiler({
   if (options.format === 'glimdown') {
     result = await service.compile('gmd', text, options as any);
   } else if (options.format === 'gjs') {
-    result = await service.compileGJS(text, { args: options.args });
+    result = await service.compileGJS(
+      text,
+      options as unknown as Record<string, unknown>
+    );
   } else if (options.format === 'hbs') {
     result = await service.compileHBS(text, options as any);
   } else {

--- a/packages/ember-repl/src/compile/compile.ts
+++ b/packages/ember-repl/src/compile/compile.ts
@@ -12,6 +12,15 @@ interface Options {
   flavor?: string;
   remarkPlugins?: unknown[];
   rehypePlugins?: unknown[];
+  /**
+   * Arguments forwarded to the compiled component.
+   *
+   * Keys present on this object at compile time become reactive `@arg`
+   * references in the rendered component. Update the values on this object
+   * (e.g. via `@tracked` or `TrackedObject`) to propagate changes into the
+   * rendered component without recompiling.
+   */
+  args?: Record<string, unknown>;
   onSuccess?: (component: ComponentLike) => Promise<unknown> | unknown;
   onError?: (error: string) => Promise<unknown> | unknown;
   onCompileStart?: () => Promise<unknown> | unknown;
@@ -67,7 +76,7 @@ async function runTheCompiler({
   if (options.format === 'glimdown') {
     result = await service.compile('gmd', text, options as any);
   } else if (options.format === 'gjs') {
-    result = await service.compileGJS(text);
+    result = await service.compileGJS(text, options as any);
   } else if (options.format === 'hbs') {
     result = await service.compileHBS(text, options as any);
   } else {

--- a/packages/ember-repl/src/index.ts
+++ b/packages/ember-repl/src/index.ts
@@ -5,5 +5,6 @@ export { getCompiler } from './services/compiler.ts';
 export { setup as setupCompiler } from './setup.ts';
 
 // Public Types
+export type { CompiledOptions } from './compile/Compiled.ts';
 export type { CompileState } from './compile/state.ts';
 export type { Format, ModuleMap, ScopeMap } from './compile/types.ts';

--- a/packages/ember-repl/src/services/compiler.ts
+++ b/packages/ember-repl/src/services/compiler.ts
@@ -387,9 +387,9 @@ export default class CompilerService {
    */
   compileGJS(
     code: string,
-    options?: { args?: Record<string, unknown> }
+    options?: Record<string, unknown>
   ): Promise<CompileResult> {
-    return this.compile('gjs', code, options as Record<string, unknown> | undefined);
+    return this.compile('gjs', code, options);
   }
 
   /**

--- a/packages/ember-repl/src/services/compiler.ts
+++ b/packages/ember-repl/src/services/compiler.ts
@@ -387,9 +387,9 @@ export default class CompilerService {
    */
   compileGJS(
     code: string,
-    options?: Record<string, unknown>
+    options?: { args?: Record<string, unknown> }
   ): Promise<CompileResult> {
-    return this.compile('gjs', code, options);
+    return this.compile('gjs', code, options as Record<string, unknown> | undefined);
   }
 
   /**

--- a/packages/ember-repl/src/services/compiler.ts
+++ b/packages/ember-repl/src/services/compiler.ts
@@ -383,9 +383,13 @@ export default class CompilerService {
    * The returned component can be invoked explicitly in the consuming project.
    *
    * @param {string} code the code to be compiled
+   * @param {object} [options] additional render options (e.g. `args`)
    */
-  compileGJS(code: string): Promise<CompileResult> {
-    return this.compile('gjs', code);
+  compileGJS(
+    code: string,
+    options?: Record<string, unknown>
+  ): Promise<CompileResult> {
+    return this.compile('gjs', code, options);
   }
 
   /**

--- a/packages/ember-repl/tests/rendering/compiled-test.gts
+++ b/packages/ember-repl/tests/rendering/compiled-test.gts
@@ -1,5 +1,4 @@
 import { tracked } from '@glimmer/tracking';
-import { hash } from '@ember/helper';
 import { renderSettled } from '@ember/renderer';
 import { render, settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
@@ -59,11 +58,11 @@ module('Rendering | Compiled()', function (hooks) {
       </template>
     `;
 
-    const args = { name: 'world' };
+    const options = { format: 'gjs' as const, args: { name: 'world' } };
 
     void render(
       <template>
-        {{#let (Compiled doc "gjs" undefined (hash args=args)) as |state|}}
+        {{#let (Compiled doc options) as |state|}}
           {{#if state.component}}
             <state.component />
           {{/if}}
@@ -88,15 +87,18 @@ module('Rendering | Compiled()', function (hooks) {
 
     // A stable args reference whose values read from tracked state.
     const state = new State();
-    const args = {
-      get name() {
-        return state.name;
+    const options = {
+      format: 'gjs' as const,
+      args: {
+        get name() {
+          return state.name;
+        },
       },
     };
 
     void render(
       <template>
-        {{#let (Compiled doc "gjs" undefined (hash args=args)) as |compiled|}}
+        {{#let (Compiled doc options) as |compiled|}}
           {{#if compiled.component}}
             <compiled.component />
           {{/if}}

--- a/packages/ember-repl/tests/rendering/compiled-test.gts
+++ b/packages/ember-repl/tests/rendering/compiled-test.gts
@@ -1,3 +1,5 @@
+import { tracked } from '@glimmer/tracking';
+import { hash } from '@ember/helper';
 import { renderSettled } from '@ember/renderer';
 import { render, settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
@@ -48,5 +50,65 @@ module('Rendering | Compiled()', function (hooks) {
     assert.dom('#ready').hasText('true');
     assert.dom('#error').hasNoText();
     assert.dom('#component').hasText('hello there');
+  });
+
+  test('forwards args to a compiled gjs component', async function (assert) {
+    const doc = stripIndent`
+      <template>
+        <output>hello {{@name}}</output>
+      </template>
+    `;
+
+    const args = { name: 'world' };
+
+    void render(
+      <template>
+        {{#let (Compiled doc "gjs" undefined (hash args=args)) as |state|}}
+          {{#if state.component}}
+            <state.component />
+          {{/if}}
+        {{/let}}
+      </template>
+    );
+
+    await settled();
+    assert.dom('output').hasText('hello world');
+  });
+
+  test('reactive args propagate without recompilation', async function (assert) {
+    const doc = stripIndent`
+      <template>
+        <output>hello {{@name}}</output>
+      </template>
+    `;
+
+    class State {
+      @tracked name = 'world';
+    }
+
+    // A stable args reference whose values read from tracked state.
+    const state = new State();
+    const args = {
+      get name() {
+        return state.name;
+      },
+    };
+
+    void render(
+      <template>
+        {{#let (Compiled doc "gjs" undefined (hash args=args)) as |compiled|}}
+          {{#if compiled.component}}
+            <compiled.component />
+          {{/if}}
+        {{/let}}
+      </template>
+    );
+
+    await settled();
+    assert.dom('output').hasText('hello world');
+
+    state.name = 'friend';
+    await settled();
+    assert.dom('output').hasText('hello friend');
   });
 });

--- a/packages/repl-sdk/src/compilers/ember/gjs.js
+++ b/packages/repl-sdk/src/compilers/ember/gjs.js
@@ -170,7 +170,16 @@ export async function compiler(config, api) {
       const { renderComponent } = await compiler.tryResolve('@ember/renderer');
 
       const owner = makeOwner(config.owner);
-      const result = renderComponent(compiled, { into: element, owner });
+      const args = /** @type {Record<string, unknown> | undefined} */ (
+        extra && typeof extra === 'object' && 'args' in extra
+          ? /** @type {Record<string, unknown>} */ (extra).args
+          : undefined
+      );
+      const result = renderComponent(compiled, {
+        into: element,
+        owner,
+        ...(args ? { args } : {}),
+      });
 
       compiler.announce('info', 'Ember Island Rendered');
 

--- a/packages/repl-sdk/src/compilers/ember/gmd.js
+++ b/packages/repl-sdk/src/compilers/ember/gmd.js
@@ -98,9 +98,16 @@ export async function compiler(config, api) {
 
       const { renderComponent } = await compiler.tryResolve('@ember/renderer');
 
+      const args = /** @type {Record<string, unknown> | undefined} */ (
+        extra && typeof extra === 'object' && 'args' in extra
+          ? /** @type {Record<string, unknown>} */ (extra).args
+          : undefined
+      );
+
       const result = renderComponent(compiled, {
         into: element,
         owner: userOptions.owner,
+        ...(args ? { args } : {}),
       });
 
       const destroy = () => result.destroy();

--- a/packages/repl-sdk/src/compilers/ember/hbs.js
+++ b/packages/repl-sdk/src/compilers/ember/hbs.js
@@ -67,7 +67,16 @@ export async function compiler(config, api) {
 
       const { renderComponent } = await compiler.tryResolve('@ember/renderer');
       const owner = makeOwner(config.owner);
-      const result = renderComponent(compiled, { into: element, owner });
+      const args = /** @type {Record<string, unknown> | undefined} */ (
+        extra && typeof extra === 'object' && 'args' in extra
+          ? /** @type {Record<string, unknown>} */ (extra).args
+          : undefined
+      );
+      const result = renderComponent(compiled, {
+        into: element,
+        owner,
+        ...(args ? { args } : {}),
+      });
 
       compiler.announce('info', 'Ember Island Rendered');
 

--- a/packages/repl-sdk/src/index.js
+++ b/packages/repl-sdk/src/index.js
@@ -345,7 +345,7 @@ export class Compiler {
   /**
    * @param {string} format
    * @param {string} text
-   * @param {{ fileName?: string, flavor?: string, [key: string]: unknown }} [ options ]
+   * @param {{ fileName?: string, flavor?: string, args?: Record<string, unknown>, [key: string]: unknown }} [ options ]
    * @returns {Promise<{ element: HTMLElement, destroy: () => void }>}
    */
   async compile(format, text, options = {}) {
@@ -411,6 +411,7 @@ export class Compiler {
       return this.#render(compiler, value, {
         ...extras,
         compiled: value,
+        ...(opts.args ? { args: opts.args } : {}),
       });
     }
 
@@ -421,7 +422,10 @@ export class Compiler {
 
     this.#log('[compile] preparing to render', defaultExport, extras);
 
-    return this.#render(compiler, defaultExport, extras);
+    return this.#render(compiler, defaultExport, {
+      ...extras,
+      ...(opts.args ? { args: opts.args } : {}),
+    });
   }
 
   #compilerCache = new WeakMap();


### PR DESCRIPTION
## Summary

- Adds an `args` option to `Compiled()` and `compile()` in `ember-repl`, threaded through `repl-sdk` into each Ember compiler's `renderComponent` call.
- Fixes `CompilerService.compileGJS` dropping the caller's options.
- Exposes `CompiledOptions` as a public type.

`renderComponent`'s `args` parameter is already reactive — passing a stable object reference whose values read from tracked state (e.g. a `TrackedObject` or an object with getters) is enough to propagate updates into the rendered component without recompiling. Keys must be present on the `args` object at compile time to become reactive references.

Usage:

```ts
@tracked name = 'world';

args = { get name() { return self.name; } };

@use compileState = Compiled(doc, 'gjs', undefined, { args: this.args });
```

Fixes #2070

## Test plan

- [x] `pnpm lint` passes (pre-existing `babel.config.cjs` format warning on `main` is unchanged)
- [x] `pnpm test:ci` passes — two new tests cover the initial args forwarding and reactive update path
- [ ] Verify on CI across browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)