### PR TITLE
fix: restore apps/ prefix in Deploy Preview matrix paths

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -141,8 +141,8 @@ jobs:
     strategy: 
       matrix:
         app: 
-        - { path: "./tutorial/dist", cloudflareName: "limber-glimmer-tutorial", name: "tutorial" }
-        - { path: "./repl/dist", cloudflareName: "limber-glimdown", name: "limber" }
+        - { path: "./apps/tutorial/dist", cloudflareName: "limber-glimmer-tutorial", name: "tutorial" }
+        - { path: "./apps/repl/dist", cloudflareName: "limber-glimdown", name: "limber" }
     steps:
       - uses: actions/download-artifact@v8
         name: deploy-prep-dist


### PR DESCRIPTION
## Problem

The Deploy Preview workflow has been failing because the `working-directory` path for the deploy steps doesn't exist after the artifact is downloaded.

Error from the logs:
```
No such file or directory: '/home/runner/work/limber/limber/./deploy-prep-dist/./tutorial/dist'
```

## Root Cause

The `Build` job uploads artifacts using the path `./apps/**/dist/**/*`. With `actions/upload-artifact@v7+`, this preserves the full directory structure, so the artifact contains:
- `apps/tutorial/dist/...`
- `apps/repl/dist/...`

After `actions/download-artifact@v8` downloads the artifact, the structure on disk is:
```
./deploy-prep-dist/apps/tutorial/dist/
./deploy-prep-dist/apps/repl/dist/
```

But the matrix paths were set to `./tutorial/dist` and `./repl/dist` (missing the `apps/` level), causing the `working-directory` to point to a non-existent path.

## Fix

Restore the `apps/` prefix in the deploy matrix paths:
- `./tutorial/dist` → `./apps/tutorial/dist`
- `./repl/dist` → `./apps/repl/dist`

This was correctly fixed in #2142 but was inadvertently reverted across the subsequent Copilot-generated PRs (#2143, #2144, #2145).

🤖 Generated with [Claude Code](https://claude.com/claude-code)