### PR TITLE
fix: add explicit path to download-artifact step to restore deploy-prep-dist subdir

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -146,6 +146,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v8
         name: deploy-prep-dist
+      - name: Debug artifact structure
+        run: find ./deploy-prep-dist -maxdepth 5 | head -40
       - name: Preview ${{ matrix.app.name }}
         working-directory: ./deploy-prep-dist/${{ matrix.app.path }}
         run: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -141,13 +141,13 @@ jobs:
     strategy: 
       matrix:
         app: 
-        - { path: "./apps/tutorial/dist", cloudflareName: "limber-glimmer-tutorial", name: "tutorial" }
-        - { path: "./apps/repl/dist", cloudflareName: "limber-glimdown", name: "limber" }
+        - { path: "./tutorial/dist", cloudflareName: "limber-glimmer-tutorial", name: "tutorial" }
+        - { path: "./repl/dist", cloudflareName: "limber-glimdown", name: "limber" }
     steps:
       - uses: actions/download-artifact@v8
         name: deploy-prep-dist
-      - name: Debug artifact structure
-        run: find ./deploy-prep-dist -maxdepth 5 | head -40
+        with:
+          path: ./deploy-prep-dist
       - name: Preview ${{ matrix.app.name }}
         working-directory: ./deploy-prep-dist/${{ matrix.app.path }}
         run: |


### PR DESCRIPTION
## Root Cause

`download-artifact@v8` changed the path logic for single-artifact runs. In **v4**:

```js
path: isSingleArtifactDownload || inputs.mergeMultiple
  ? resolvedPath
  : path.join(resolvedPath, artifact.name)
```

In **v8**, they added `|| artifacts.length === 1`:

```js
path: isSingleArtifactDownload || inputs.mergeMultiple || artifacts.length === 1
  ? resolvedPath
  : path.join(resolvedPath, artifact.name)
```

Since this workflow only has **one artifact** (`deploy-prep-dist`), v8 now extracts files directly to the workspace root instead of creating a `deploy-prep-dist/` subdirectory. The `working-directory: ./deploy-prep-dist/...` then points to a non-existent path.

## Fix

Add `path: ./deploy-prep-dist` to the download step so the extraction location is **explicit** and doesn't depend on artifact count behavior:

```yaml
- uses: actions/download-artifact@v8
  with:
    path: ./deploy-prep-dist
```

Also reverts the incorrect `apps/` prefix added by the previous PR — the artifact stores paths relative to the `apps/` directory (since that's the LCA of the upload glob `./apps/**/dist/**/*`), so the correct matrix paths remain `./tutorial/dist` and `./repl/dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)