### PR TITLE
Add renderToString to repl-sdk + ember-repl

### DIFF
--- a/packages/ember-repl/src/services/compiler.ts
+++ b/packages/ember-repl/src/services/compiler.ts
@@ -426,6 +426,39 @@ export default class CompilerService {
   ): Promise<CompileResult> {
     return this.compile('md', source, options);
   }
+
+  /**
+   * @public
+   *
+   * Build-time variant of {@link CompilerService.compile}: returns the
+   * compiled JS module source as a string instead of an evaluated component.
+   *
+   * Intended for SSG / pre-rendering pipelines that want to take the output
+   * of a live demo (or a `gmd` document containing many demos) and hand it
+   * to their own bundler, rather than evaluating it in the browser at boot.
+   *
+   * The returned string is a `.gjs`-shaped ES module — top-level imports
+   * plus an `export default` — that the consuming app's content-tag + babel
+   * pipeline can precompile to wire format.
+   */
+  @waitFor
+  async compileToSource(
+    ext: string,
+    text: string,
+    options?: Record<string, unknown>
+  ): Promise<{ source: string }> {
+    this.messages = [];
+
+    await Promise.resolve();
+
+    const opts = { ...(options ?? {}) };
+
+    if (ext === 'hbs') {
+      opts.flavor = 'ember';
+    }
+
+    return this.compiler.compileToSource(ext, text, opts);
+  }
 }
 
 function getGlobal() {

--- a/packages/ember-repl/src/services/compiler.ts
+++ b/packages/ember-repl/src/services/compiler.ts
@@ -363,10 +363,7 @@ export default class CompilerService {
         options.flavor = 'ember';
       }
 
-      const result = (await this.#compile(ext, text, options)) as {
-        element: HTMLElement;
-        destroy: () => void;
-      };
+      const result = await this.#compile(ext, text, options);
 
       component = rendersElement(result);
     } catch (e) {

--- a/packages/ember-repl/src/services/compiler.ts
+++ b/packages/ember-repl/src/services/compiler.ts
@@ -363,7 +363,10 @@ export default class CompilerService {
         options.flavor = 'ember';
       }
 
-      const result = await this.#compile(ext, text, options);
+      const result = (await this.#compile(ext, text, options)) as {
+        element: HTMLElement;
+        destroy: () => void;
+      };
 
       component = rendersElement(result);
     } catch (e) {

--- a/packages/repl-sdk/package.json
+++ b/packages/repl-sdk/package.json
@@ -51,6 +51,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@babel/standalone": "file:babel-standalone.tgz",
     "@nullvoxpopuli/eslint-configs": "^5.4.0",
     "@tsconfig/ember": "^3.0.7",
     "@types/common-tags": "^1.8.4",

--- a/packages/repl-sdk/src/compilers/ember/gmd.js
+++ b/packages/repl-sdk/src/compilers/ember/gmd.js
@@ -9,13 +9,16 @@ let elementId = 0;
 let scopeNonce = 0;
 
 /**
- * Symbol-keyed slot on `globalThis` where gmd's runtime path stashes the live
- * scope object so the emitted ES module can read it back at evaluation time.
+ * Slot on `globalThis` where gmd's runtime path stashes the live scope object
+ * so the emitted ES module can read it back at evaluation time. String-keyed
+ * (rather than Symbol-keyed) so TypeScript accepts the indexed access on
+ * `globalThis` without a cast — `globalThis[string]` is well-typed as
+ * `unknown`.
  *
  * @param {number} id
  */
 function scopeKey(id) {
-  return Symbol.for(`repl-sdk:gmd-scope:${id}`);
+  return `__replSdk__gmdScope__${id}`;
 }
 
 /**
@@ -105,11 +108,8 @@ export async function compiler(config, api) {
 
       let nth = 0;
 
-      for (const info of /** @type {Array<Record<string, unknown>>} */ (result.codeBlocks)) {
-        const format = /** @type {string} */ (info.format);
-        const flavor = /** @type {string | undefined} */ (info.flavor);
-        const code = /** @type {string} */ (info.code);
-        const placeholderId = /** @type {string} */ (info.placeholderId);
+      for (const info of result.codeBlocks) {
+        const { format, flavor, code, placeholderId } = info;
 
         if (!api.canCompile(format, flavor).result) continue;
 
@@ -143,14 +143,17 @@ export async function compiler(config, api) {
       const id = ++scopeNonce;
       const key = scopeKey(id);
 
-      /** @type {Record<symbol, unknown>} */ (globalThis)[key] = scope;
+      // `Reflect.set` writes the dynamic key onto `globalThis` without
+      // needing a cast — `typeof globalThis` doesn't have a string index
+      // signature, but `Reflect.set` accepts any `PropertyKey`.
+      Reflect.set(globalThis, key, scope);
 
       const source = buildGmdModule({
         prose: result.text,
         demos,
         templateModule: '@ember/template-compiler/runtime',
         scope: {
-          expression: `globalThis[Symbol.for('repl-sdk:gmd-scope:${id}')]`,
+          expression: `globalThis['${key}']`,
           keys: Object.keys(scope),
         },
       });
@@ -185,15 +188,16 @@ export async function compiler(config, api) {
       return () => {
         result.destroy();
 
-        // Release the stashed scope so it's eligible for GC. The nonce is
-        // shape-typed on `extra` so we know exactly which slot to clear.
-        const nonce =
-          extra && typeof extra === 'object' && '__replSdkScopeNonce' in extra
-            ? /** @type {number} */ (extra.__replSdkScopeNonce)
-            : undefined;
-
-        if (typeof nonce === 'number') {
-          delete /** @type {Record<symbol, unknown>} */ (globalThis)[scopeKey(nonce)];
+        // Release the stashed scope so it's eligible for GC. The nonce was
+        // attached to `extra` by `compile()` so we know exactly which slot
+        // to clear.
+        if (
+          extra &&
+          typeof extra === 'object' &&
+          '__replSdkScopeNonce' in extra &&
+          typeof extra.__replSdkScopeNonce === 'number'
+        ) {
+          Reflect.deleteProperty(globalThis, scopeKey(extra.__replSdkScopeNonce));
         }
       };
     },

--- a/packages/repl-sdk/src/compilers/ember/gmd.js
+++ b/packages/repl-sdk/src/compilers/ember/gmd.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('unified').Plugin} Plugin
  */
+import { buildGmdModule } from '../../render-to-string.js';
 import { assert, isRecord } from '../../utils.js';
 import { buildCodeFenceMetaUtils } from '../markdown/utils.js';
 
@@ -68,6 +69,10 @@ export async function compiler(config, api) {
         getFlavorFromMeta,
       });
 
+      if (isRecord(options) && options.renderToString) {
+        return compileToSource(result, options);
+      }
+
       const { template } = await api.tryResolve('@ember/template-compiler/runtime');
 
       const scope = {
@@ -134,19 +139,21 @@ export async function compiler(config, api) {
           const flavor = /** @type {string} */ (infoObj.flavor);
           const hasScope =
             flavor === 'ember' || infoObj.format === 'gjs' || infoObj.format === 'hbs';
-          const subRender = await compiler.compile(
-            /** @type {string} */ (infoObj.format),
-            /** @type {string} */ (infoObj.code),
-            {
-              ...compiler.optionsFor(/** @type {string} */ (infoObj.format), flavor),
-              flavor: flavor,
-              // @ts-ignore
-              ...(hasScope
-                ? {
-                    scope: extra.scope,
-                  }
-                : {}),
-            }
+          const subRender = /** @type {{ element: HTMLElement, destroy: () => void }} */ (
+            await compiler.compile(
+              /** @type {string} */ (infoObj.format),
+              /** @type {string} */ (infoObj.code),
+              {
+                ...compiler.optionsFor(/** @type {string} */ (infoObj.format), flavor),
+                flavor: flavor,
+                // @ts-ignore
+                ...(hasScope
+                  ? {
+                      scope: extra.scope,
+                    }
+                  : {}),
+              }
+            )
           );
 
           const selector = `#${/** @type {string} */ (infoObj.placeholderId)}`;
@@ -174,4 +181,65 @@ export async function compiler(config, api) {
   };
 
   return gmdCompiler;
+
+  /**
+   * Build-time path: turn a parsed markdown result into a single ES module
+   * string that the host app's compiler can take to SSG-renderable output.
+   *
+   * Strategy:
+   *
+   *   1. For every live code block, recursively call the sub-compiler in
+   *      `renderToString: true` mode to get its babel-compiled module string.
+   *   2. Split each demo module into `{ imports, body }` and wrap the body in
+   *      `const Demo<N> = (() => { ...; return _component; })();`.
+   *   3. Replace the `<div id="placeholderId">…</div>` HTML placeholder for
+   *      each demo with a `<Demo<N> />` Glimmer component invocation.
+   *   4. Emit one module that imports `template` from
+   *      `@ember/template-compiler` (build-time), declares all the inlined
+   *      demo consts, and `export default`s a `template(prose, { scope })`
+   *      call referencing them.
+   *
+   * The output is *not* itself precompiled — it's a `.gjs`-shaped JS module
+   * that the host app's content-tag + babel pipeline will precompile to wire
+   * format, the same way it would for any other live `.gjs` file.
+   *
+   * @param {{ text: string, codeBlocks: Array<Record<string, unknown>> }} result
+   * @param {Record<string, unknown>} options
+   * @returns {Promise<{ source: string }>}
+   */
+  async function compileToSource(result, options) {
+    /** @type {Array<{ name: string, placeholderId: string, source: string }>} */
+    const demos = [];
+
+    let nth = 0;
+
+    for (const info of result.codeBlocks) {
+      const format = /** @type {string} */ (info.format);
+      const flavor = /** @type {string | undefined} */ (info.flavor);
+      const code = /** @type {string} */ (info.code);
+      const placeholderId = /** @type {string} */ (info.placeholderId);
+
+      if (!api.canCompile(format, flavor).result) {
+        continue;
+      }
+
+      nth++;
+
+      const demoName = `Demo${nth}`;
+      const subOptions = {
+        ...(options ?? {}),
+        flavor,
+        renderToString: true,
+      };
+
+      // `api` exposes `compileToSource` so a compiler can recursively ask for
+      // the build-time form of another compiler — gmd needs this to inline
+      // each live code block into the single emitted module.
+      const subResult = await api.compileToSource(format, code, subOptions);
+
+      demos.push({ name: demoName, placeholderId, source: subResult.source });
+    }
+
+    return { source: buildGmdModule({ prose: result.text, demos }) };
+  }
 }

--- a/packages/repl-sdk/src/compilers/ember/gmd.js
+++ b/packages/repl-sdk/src/compilers/ember/gmd.js
@@ -2,10 +2,21 @@
  * @typedef {import('unified').Plugin} Plugin
  */
 import { buildGmdModule } from '../../render-to-string.js';
-import { assert, isRecord } from '../../utils.js';
+import { isRecord } from '../../utils.js';
 import { buildCodeFenceMetaUtils } from '../markdown/utils.js';
 
 let elementId = 0;
+let scopeNonce = 0;
+
+/**
+ * Symbol-keyed slot on `globalThis` where gmd's runtime path stashes the live
+ * scope object so the emitted ES module can read it back at evaluation time.
+ *
+ * @param {number} id
+ */
+function scopeKey(id) {
+  return Symbol.for(`repl-sdk:gmd-scope:${id}`);
+}
 
 /**
  * @param {unknown} [ options ]
@@ -56,6 +67,26 @@ export async function compiler(config, api) {
    * @type {import('../../types.ts').Compiler}
    */
   const gmdCompiler = {
+    /**
+     * The runtime and renderToString paths share most of their work — both
+     * parse the markdown, recursively compile every live demo to a JS
+     * source string, then call `buildGmdModule` to inline those demos into
+     * a single `.gjs`-shaped module.
+     *
+     * The only forks are:
+     *
+     *   - Which `@ember/template-compiler` to import. Runtime form uses
+     *     `/runtime` (the parse-and-compile-at-execution-time variant);
+     *     renderToString uses the build-time form so the host app's babel
+     *     pipeline can precompile the `template()` call to wire format.
+     *
+     *   - How runtime scope crosses the source boundary. The build-time
+     *     form can't reference a live JS object, so renderToString gets
+     *     an empty scope. The runtime form stashes the live scope object
+     *     on `globalThis[Symbol.for('repl-sdk:gmd-scope:N')]` and emits a
+     *     module that reads it back and destructures its keys into the
+     *     template's `scope: () => ({...})` call.
+     */
     compile: async (text, options) => {
       const compileOptions = filterOptions(options);
       const result = await parseMarkdown(text, {
@@ -69,26 +100,62 @@ export async function compiler(config, api) {
         getFlavorFromMeta,
       });
 
-      if (isRecord(options) && options.renderToString) {
-        return compileToSource(result, options);
+      /** @type {Array<{ name: string, placeholderId: string, source: string }>} */
+      const demos = [];
+
+      let nth = 0;
+
+      for (const info of /** @type {Array<Record<string, unknown>>} */ (result.codeBlocks)) {
+        const format = /** @type {string} */ (info.format);
+        const flavor = /** @type {string | undefined} */ (info.flavor);
+        const code = /** @type {string} */ (info.code);
+        const placeholderId = /** @type {string} */ (info.placeholderId);
+
+        if (!api.canCompile(format, flavor).result) continue;
+
+        nth++;
+
+        const sub = await api.compileToSource(format, code, {
+          ...(options ?? {}),
+          flavor,
+        });
+
+        demos.push({ name: `Demo${nth}`, placeholderId, source: sub.source });
       }
 
-      const { template } = await api.tryResolve('@ember/template-compiler/runtime');
-
+      const renderToString = isRecord(options) && options.renderToString === true;
       const scope = {
-        ...filterOptions(userOptions).scope,
-        ...filterOptions(options).scope,
+        ...userOptions.scope,
+        ...compileOptions.scope,
       };
 
-      const component = template(result.text, {
-        scope: () => ({
-          ...scope,
-          // TODO: compile all the components from "result" and add them to scope here
-          //       would this be better than the markdown style multiple islands
-        }),
+      if (renderToString) {
+        const source = buildGmdModule({
+          prose: result.text,
+          demos,
+          templateModule: '@ember/template-compiler',
+          scope: null,
+        });
+
+        return { source };
+      }
+
+      const id = ++scopeNonce;
+      const key = scopeKey(id);
+
+      /** @type {Record<symbol, unknown>} */ (globalThis)[key] = scope;
+
+      const source = buildGmdModule({
+        prose: result.text,
+        demos,
+        templateModule: '@ember/template-compiler/runtime',
+        scope: {
+          expression: `globalThis[Symbol.for('repl-sdk:gmd-scope:${id}')]`,
+          keys: Object.keys(scope),
+        },
       });
 
-      return { compiled: component, ...result, scope };
+      return { compiled: source, ...result, scope, __replSdkScopeNonce: id };
     },
     render: async (element, compiled, extra, compiler) => {
       /**
@@ -115,131 +182,22 @@ export async function compiler(config, api) {
         ...(args ? { args } : {}),
       });
 
-      const destroy = () => result.destroy();
-
-      /**
-       * @type {(() => void)[]}
-       */
-      const destroyables = [];
-
-      await Promise.all(
-        /** @type {unknown[]} */ (extra.codeBlocks).map(async (/** @type {unknown} */ info) => {
-          /** @type {Record<string, unknown>} */
-          const infoObj = /** @type {Record<string, unknown>} */ (info);
-
-          if (
-            !api.canCompile(
-              /** @type {string} */ (infoObj.format),
-              /** @type {string} */ (infoObj.flavor)
-            )
-          ) {
-            return;
-          }
-
-          const flavor = /** @type {string} */ (infoObj.flavor);
-          const hasScope =
-            flavor === 'ember' || infoObj.format === 'gjs' || infoObj.format === 'hbs';
-          const subRender = /** @type {{ element: HTMLElement, destroy: () => void }} */ (
-            await compiler.compile(
-              /** @type {string} */ (infoObj.format),
-              /** @type {string} */ (infoObj.code),
-              {
-                ...compiler.optionsFor(/** @type {string} */ (infoObj.format), flavor),
-                flavor: flavor,
-                // @ts-ignore
-                ...(hasScope
-                  ? {
-                      scope: extra.scope,
-                    }
-                  : {}),
-              }
-            )
-          );
-
-          const selector = `#${/** @type {string} */ (infoObj.placeholderId)}`;
-          const target = element.querySelector(selector);
-
-          assert(
-            `Could not find placeholder / target element (using selector: \`${selector}\`). ` +
-              `Could not render ${/** @type {string} */ (infoObj.format)} block.`,
-            target
-          );
-
-          destroyables.push(subRender.destroy);
-          target.appendChild(subRender.element);
-        })
-      );
-
       return () => {
-        for (const subDestroy of destroyables) {
-          subDestroy();
-        }
+        result.destroy();
 
-        destroy();
+        // Release the stashed scope so it's eligible for GC. The nonce is
+        // shape-typed on `extra` so we know exactly which slot to clear.
+        const nonce =
+          extra && typeof extra === 'object' && '__replSdkScopeNonce' in extra
+            ? /** @type {number} */ (extra.__replSdkScopeNonce)
+            : undefined;
+
+        if (typeof nonce === 'number') {
+          delete /** @type {Record<symbol, unknown>} */ (globalThis)[scopeKey(nonce)];
+        }
       };
     },
   };
 
   return gmdCompiler;
-
-  /**
-   * Build-time path: turn a parsed markdown result into a single ES module
-   * string that the host app's compiler can take to SSG-renderable output.
-   *
-   * Strategy:
-   *
-   *   1. For every live code block, recursively call the sub-compiler in
-   *      `renderToString: true` mode to get its babel-compiled module string.
-   *   2. Split each demo module into `{ imports, body }` and wrap the body in
-   *      `const Demo<N> = (() => { ...; return _component; })();`.
-   *   3. Replace the `<div id="placeholderId">…</div>` HTML placeholder for
-   *      each demo with a `<Demo<N> />` Glimmer component invocation.
-   *   4. Emit one module that imports `template` from
-   *      `@ember/template-compiler` (build-time), declares all the inlined
-   *      demo consts, and `export default`s a `template(prose, { scope })`
-   *      call referencing them.
-   *
-   * The output is *not* itself precompiled — it's a `.gjs`-shaped JS module
-   * that the host app's content-tag + babel pipeline will precompile to wire
-   * format, the same way it would for any other live `.gjs` file.
-   *
-   * @param {{ text: string, codeBlocks: Array<Record<string, unknown>> }} result
-   * @param {Record<string, unknown>} options
-   * @returns {Promise<{ source: string }>}
-   */
-  async function compileToSource(result, options) {
-    /** @type {Array<{ name: string, placeholderId: string, source: string }>} */
-    const demos = [];
-
-    let nth = 0;
-
-    for (const info of result.codeBlocks) {
-      const format = /** @type {string} */ (info.format);
-      const flavor = /** @type {string | undefined} */ (info.flavor);
-      const code = /** @type {string} */ (info.code);
-      const placeholderId = /** @type {string} */ (info.placeholderId);
-
-      if (!api.canCompile(format, flavor).result) {
-        continue;
-      }
-
-      nth++;
-
-      const demoName = `Demo${nth}`;
-      const subOptions = {
-        ...(options ?? {}),
-        flavor,
-        renderToString: true,
-      };
-
-      // `api` exposes `compileToSource` so a compiler can recursively ask for
-      // the build-time form of another compiler — gmd needs this to inline
-      // each live code block into the single emitted module.
-      const subResult = await api.compileToSource(format, code, subOptions);
-
-      demos.push({ name: demoName, placeholderId, source: subResult.source });
-    }
-
-    return { source: buildGmdModule({ prose: result.text, demos }) };
-  }
 }

--- a/packages/repl-sdk/src/compilers/ember/gmd.js
+++ b/packages/repl-sdk/src/compilers/ember/gmd.js
@@ -9,16 +9,16 @@ let elementId = 0;
 let scopeNonce = 0;
 
 /**
- * Slot on `globalThis` where gmd's runtime path stashes the live scope object
- * so the emitted ES module can read it back at evaluation time. String-keyed
- * (rather than Symbol-keyed) so TypeScript accepts the indexed access on
- * `globalThis` without a cast — `globalThis[string]` is well-typed as
- * `unknown`.
+ * Virtual ES module specifier under which gmd's runtime path registers the
+ * live scope object via `api.provide`. The emitted module then imports its
+ * scope from this specifier — Compiler's existing `manual:` resolver takes
+ * care of handing the registered value back, so individual compilers don't
+ * need to know how the bridge is implemented.
  *
  * @param {number} id
  */
-function scopeKey(id) {
-  return `__replSdk__gmdScope__${id}`;
+function scopeSpecifier(id) {
+  return `repl-sdk:gmd-scope:${id}`;
 }
 
 /**
@@ -85,10 +85,11 @@ export async function compiler(config, api) {
      *
      *   - How runtime scope crosses the source boundary. The build-time
      *     form can't reference a live JS object, so renderToString gets
-     *     an empty scope. The runtime form stashes the live scope object
-     *     on `globalThis[Symbol.for('repl-sdk:gmd-scope:N')]` and emits a
-     *     module that reads it back and destructures its keys into the
-     *     template's `scope: () => ({...})` call.
+     *     an empty scope. The runtime form registers the live scope object
+     *     behind a virtual ES module specifier via `api.provide` and emits
+     *     a module that `import * as __scope__ from '<specifier>'`. The
+     *     Compiler's existing `manual:` resolver handles the bridge, so
+     *     gmd never touches `globalThis` directly.
      */
     compile: async (text, options) => {
       const compileOptions = filterOptions(options);
@@ -140,25 +141,20 @@ export async function compiler(config, api) {
         return { source };
       }
 
-      const id = ++scopeNonce;
-      const key = scopeKey(id);
-
-      // `Reflect.set` writes the dynamic key onto `globalThis` without
-      // needing a cast — `typeof globalThis` doesn't have a string index
-      // signature, but `Reflect.set` accepts any `PropertyKey`.
-      Reflect.set(globalThis, key, scope);
+      const specifier = scopeSpecifier(++scopeNonce);
+      const unregisterScope = api.provide(specifier, scope);
 
       const source = buildGmdModule({
         prose: result.text,
         demos,
         templateModule: '@ember/template-compiler/runtime',
         scope: {
-          expression: `globalThis['${key}']`,
+          specifier,
           keys: Object.keys(scope),
         },
       });
 
-      return { compiled: source, ...result, scope, __replSdkScopeNonce: id };
+      return { compiled: source, ...result, scope, __replSdkUnregisterScope: unregisterScope };
     },
     render: async (element, compiled, extra, compiler) => {
       /**
@@ -188,16 +184,16 @@ export async function compiler(config, api) {
       return () => {
         result.destroy();
 
-        // Release the stashed scope so it's eligible for GC. The nonce was
-        // attached to `extra` by `compile()` so we know exactly which slot
-        // to clear.
+        // Release the registered scope so it's eligible for GC. `compile()`
+        // attached the unregister callback to `extra` so we know which
+        // entry to clear.
         if (
           extra &&
           typeof extra === 'object' &&
-          '__replSdkScopeNonce' in extra &&
-          typeof extra.__replSdkScopeNonce === 'number'
+          '__replSdkUnregisterScope' in extra &&
+          typeof extra.__replSdkUnregisterScope === 'function'
         ) {
-          Reflect.deleteProperty(globalThis, scopeKey(extra.__replSdkScopeNonce));
+          extra.__replSdkUnregisterScope();
         }
       };
     },

--- a/packages/repl-sdk/src/compilers/ember/gmd.js
+++ b/packages/repl-sdk/src/compilers/ember/gmd.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('unified').Plugin} Plugin
  */
+import { buildGmdModule } from '../../render-to-string.js';
 import { assert, isRecord } from '../../utils.js';
 import { buildCodeFenceMetaUtils } from '../markdown/utils.js';
 import { makeOwner } from './owner.js';
@@ -68,6 +69,10 @@ export async function compiler(config, api) {
         ALLOWED_FORMATS: allowedFormats,
         getFlavorFromMeta,
       });
+
+      if (isRecord(options) && options.renderToString) {
+        return compileToSource(result, options);
+      }
 
       const { template } = await api.tryResolve('@ember/template-compiler/runtime');
 
@@ -141,19 +146,21 @@ export async function compiler(config, api) {
           const flavor = /** @type {string} */ (infoObj.flavor);
           const hasScope =
             flavor === 'ember' || infoObj.format === 'gjs' || infoObj.format === 'hbs';
-          const subRender = await compiler.compile(
-            /** @type {string} */ (infoObj.format),
-            /** @type {string} */ (infoObj.code),
-            {
-              ...compiler.optionsFor(/** @type {string} */ (infoObj.format), flavor),
-              flavor: flavor,
-              // @ts-ignore
-              ...(hasScope
-                ? {
-                    scope: extra.scope,
-                  }
-                : {}),
-            }
+          const subRender = /** @type {{ element: HTMLElement, destroy: () => void }} */ (
+            await compiler.compile(
+              /** @type {string} */ (infoObj.format),
+              /** @type {string} */ (infoObj.code),
+              {
+                ...compiler.optionsFor(/** @type {string} */ (infoObj.format), flavor),
+                flavor: flavor,
+                // @ts-ignore
+                ...(hasScope
+                  ? {
+                      scope: extra.scope,
+                    }
+                  : {}),
+              }
+            )
           );
 
           const selector = `#${/** @type {string} */ (infoObj.placeholderId)}`;
@@ -181,4 +188,65 @@ export async function compiler(config, api) {
   };
 
   return gmdCompiler;
+
+  /**
+   * Build-time path: turn a parsed markdown result into a single ES module
+   * string that the host app's compiler can take to SSG-renderable output.
+   *
+   * Strategy:
+   *
+   *   1. For every live code block, recursively call the sub-compiler in
+   *      `renderToString: true` mode to get its babel-compiled module string.
+   *   2. Split each demo module into `{ imports, body }` and wrap the body in
+   *      `const Demo<N> = (() => { ...; return _component; })();`.
+   *   3. Replace the `<div id="placeholderId">…</div>` HTML placeholder for
+   *      each demo with a `<Demo<N> />` Glimmer component invocation.
+   *   4. Emit one module that imports `template` from
+   *      `@ember/template-compiler` (build-time), declares all the inlined
+   *      demo consts, and `export default`s a `template(prose, { scope })`
+   *      call referencing them.
+   *
+   * The output is *not* itself precompiled — it's a `.gjs`-shaped JS module
+   * that the host app's content-tag + babel pipeline will precompile to wire
+   * format, the same way it would for any other live `.gjs` file.
+   *
+   * @param {{ text: string, codeBlocks: Array<Record<string, unknown>> }} result
+   * @param {Record<string, unknown>} options
+   * @returns {Promise<{ source: string }>}
+   */
+  async function compileToSource(result, options) {
+    /** @type {Array<{ name: string, placeholderId: string, source: string }>} */
+    const demos = [];
+
+    let nth = 0;
+
+    for (const info of result.codeBlocks) {
+      const format = /** @type {string} */ (info.format);
+      const flavor = /** @type {string | undefined} */ (info.flavor);
+      const code = /** @type {string} */ (info.code);
+      const placeholderId = /** @type {string} */ (info.placeholderId);
+
+      if (!api.canCompile(format, flavor).result) {
+        continue;
+      }
+
+      nth++;
+
+      const demoName = `Demo${nth}`;
+      const subOptions = {
+        ...(options ?? {}),
+        flavor,
+        renderToString: true,
+      };
+
+      // `api` exposes `compileToSource` so a compiler can recursively ask for
+      // the build-time form of another compiler — gmd needs this to inline
+      // each live code block into the single emitted module.
+      const subResult = await api.compileToSource(format, code, subOptions);
+
+      demos.push({ name: demoName, placeholderId, source: subResult.source });
+    }
+
+    return { source: buildGmdModule({ prose: result.text, demos }) };
+  }
 }

--- a/packages/repl-sdk/src/compilers/ember/gmd.js
+++ b/packages/repl-sdk/src/compilers/ember/gmd.js
@@ -91,6 +91,12 @@ export async function compiler(config, api) {
         getFlavorFromMeta,
       });
 
+      const renderToString = isRecord(options) && options.renderToString === true;
+      const scope = {
+        ...userOptions.scope,
+        ...compileOptions.scope,
+      };
+
       /** @type {Array<{ name: string, placeholderId: string, source: string }>} */
       const demos = [];
 
@@ -103,19 +109,24 @@ export async function compiler(config, api) {
 
         nth++;
 
+        // On the runtime path each demo is inlined into this module, so it can
+        // read the live scope off the same `__scope__` namespace the prose
+        // uses. Handing the sub-compiler the same template module also keeps
+        // `mergeImports` from emitting two conflicting `template` bindings.
         const sub = await api.compileToSource(format, code, {
           ...(options ?? {}),
           flavor,
+          ...(renderToString
+            ? {}
+            : {
+                inlineTemplateModule: '@ember/template-compiler/runtime',
+                inlineScopeKeys: Object.keys(scope),
+                inlineScopeNamespace: '__scope__',
+              }),
         });
 
         demos.push({ name: `Demo${nth}`, placeholderId, source: sub.source });
       }
-
-      const renderToString = isRecord(options) && options.renderToString === true;
-      const scope = {
-        ...userOptions.scope,
-        ...compileOptions.scope,
-      };
 
       if (renderToString) {
         const source = buildGmdModule({

--- a/packages/repl-sdk/src/compilers/ember/gmd.js
+++ b/packages/repl-sdk/src/compilers/ember/gmd.js
@@ -2,25 +2,11 @@
  * @typedef {import('unified').Plugin} Plugin
  */
 import { buildGmdModule } from '../../render-to-string.js';
-import { isRecord } from '../../utils.js';
+import { assert, isRecord } from '../../utils.js';
 import { buildCodeFenceMetaUtils } from '../markdown/utils.js';
 import { makeOwner } from './owner.js';
 
 let elementId = 0;
-let scopeNonce = 0;
-
-/**
- * Virtual ES module specifier under which gmd's runtime path registers the
- * live scope object via `api.provide`. The emitted module then imports its
- * scope from this specifier — Compiler's existing `manual:` resolver takes
- * care of handing the registered value back, so individual compilers don't
- * need to know how the bridge is implemented.
- *
- * @param {number} id
- */
-function scopeSpecifier(id) {
-  return `repl-sdk:gmd-scope:${id}`;
-}
 
 /**
  * @param {unknown} [ options ]
@@ -92,7 +78,7 @@ export async function compiler(config, api) {
      *     Compiler's existing `manual:` resolver handles the bridge, so
      *     gmd never touches `globalThis` directly.
      */
-    compile: async (text, options) => {
+    compile: async (text, options, compileApi) => {
       const compileOptions = filterOptions(options);
       const result = await parseMarkdown(text, {
         remarkPlugins: [...userOptions.remarkPlugins, ...compileOptions.remarkPlugins],
@@ -142,8 +128,17 @@ export async function compiler(config, api) {
         return { source };
       }
 
-      const specifier = scopeSpecifier(++scopeNonce);
-      const unregisterScope = api.provide(specifier, scope);
+      // `compileApi.provideScope` registers the live scope behind a
+      // Compiler-generated specifier and tracks it as part of this
+      // compile's lifecycle. The Compiler releases it when destroy fires;
+      // gmd doesn't need to track an unregister callback.
+      assert(
+        `gmd needs the per-compile API (3rd argument to compile) to provide its scope. ` +
+          `It looks like the Compiler did not pass one.`,
+        compileApi
+      );
+
+      const { specifier } = compileApi.provideScope(scope);
 
       const source = buildGmdModule({
         prose: result.text,
@@ -155,7 +150,7 @@ export async function compiler(config, api) {
         },
       });
 
-      return { compiled: source, ...result, scope, __replSdkUnregisterScope: unregisterScope };
+      return { compiled: source, ...result, scope };
     },
     render: async (element, compiled, extra, compiler) => {
       /**
@@ -188,21 +183,7 @@ export async function compiler(config, api) {
         ...(args ? { args } : {}),
       });
 
-      return () => {
-        result.destroy();
-
-        // Release the registered scope so it's eligible for GC. `compile()`
-        // attached the unregister callback to `extra` so we know which
-        // entry to clear.
-        if (
-          extra &&
-          typeof extra === 'object' &&
-          '__replSdkUnregisterScope' in extra &&
-          typeof extra.__replSdkUnregisterScope === 'function'
-        ) {
-          extra.__replSdkUnregisterScope();
-        }
-      };
+      return () => result.destroy();
     },
   };
 

--- a/packages/repl-sdk/src/compilers/ember/gmd.js
+++ b/packages/repl-sdk/src/compilers/ember/gmd.js
@@ -2,11 +2,22 @@
  * @typedef {import('unified').Plugin} Plugin
  */
 import { buildGmdModule } from '../../render-to-string.js';
-import { assert, isRecord } from '../../utils.js';
+import { isRecord } from '../../utils.js';
 import { buildCodeFenceMetaUtils } from '../markdown/utils.js';
 import { makeOwner } from './owner.js';
 
 let elementId = 0;
+let scopeNonce = 0;
+
+/**
+ * Symbol-keyed slot on `globalThis` where gmd's runtime path stashes the live
+ * scope object so the emitted ES module can read it back at evaluation time.
+ *
+ * @param {number} id
+ */
+function scopeKey(id) {
+  return Symbol.for(`repl-sdk:gmd-scope:${id}`);
+}
 
 /**
  * @param {unknown} [ options ]
@@ -57,6 +68,26 @@ export async function compiler(config, api) {
    * @type {import('../../types.ts').Compiler}
    */
   const gmdCompiler = {
+    /**
+     * The runtime and renderToString paths share most of their work — both
+     * parse the markdown, recursively compile every live demo to a JS
+     * source string, then call `buildGmdModule` to inline those demos into
+     * a single `.gjs`-shaped module.
+     *
+     * The only forks are:
+     *
+     *   - Which `@ember/template-compiler` to import. Runtime form uses
+     *     `/runtime` (the parse-and-compile-at-execution-time variant);
+     *     renderToString uses the build-time form so the host app's babel
+     *     pipeline can precompile the `template()` call to wire format.
+     *
+     *   - How runtime scope crosses the source boundary. The build-time
+     *     form can't reference a live JS object, so renderToString gets
+     *     an empty scope. The runtime form stashes the live scope object
+     *     on `globalThis[Symbol.for('repl-sdk:gmd-scope:N')]` and emits a
+     *     module that reads it back and destructures its keys into the
+     *     template's `scope: () => ({...})` call.
+     */
     compile: async (text, options) => {
       const compileOptions = filterOptions(options);
       const result = await parseMarkdown(text, {
@@ -70,26 +101,62 @@ export async function compiler(config, api) {
         getFlavorFromMeta,
       });
 
-      if (isRecord(options) && options.renderToString) {
-        return compileToSource(result, options);
+      /** @type {Array<{ name: string, placeholderId: string, source: string }>} */
+      const demos = [];
+
+      let nth = 0;
+
+      for (const info of /** @type {Array<Record<string, unknown>>} */ (result.codeBlocks)) {
+        const format = /** @type {string} */ (info.format);
+        const flavor = /** @type {string | undefined} */ (info.flavor);
+        const code = /** @type {string} */ (info.code);
+        const placeholderId = /** @type {string} */ (info.placeholderId);
+
+        if (!api.canCompile(format, flavor).result) continue;
+
+        nth++;
+
+        const sub = await api.compileToSource(format, code, {
+          ...(options ?? {}),
+          flavor,
+        });
+
+        demos.push({ name: `Demo${nth}`, placeholderId, source: sub.source });
       }
 
-      const { template } = await api.tryResolve('@ember/template-compiler/runtime');
-
+      const renderToString = isRecord(options) && options.renderToString === true;
       const scope = {
-        ...filterOptions(userOptions).scope,
-        ...filterOptions(options).scope,
+        ...userOptions.scope,
+        ...compileOptions.scope,
       };
 
-      const component = template(result.text, {
-        scope: () => ({
-          ...scope,
-          // TODO: compile all the components from "result" and add them to scope here
-          //       would this be better than the markdown style multiple islands
-        }),
+      if (renderToString) {
+        const source = buildGmdModule({
+          prose: result.text,
+          demos,
+          templateModule: '@ember/template-compiler',
+          scope: null,
+        });
+
+        return { source };
+      }
+
+      const id = ++scopeNonce;
+      const key = scopeKey(id);
+
+      /** @type {Record<symbol, unknown>} */ (globalThis)[key] = scope;
+
+      const source = buildGmdModule({
+        prose: result.text,
+        demos,
+        templateModule: '@ember/template-compiler/runtime',
+        scope: {
+          expression: `globalThis[Symbol.for('repl-sdk:gmd-scope:${id}')]`,
+          keys: Object.keys(scope),
+        },
       });
 
-      return { compiled: component, ...result, scope };
+      return { compiled: source, ...result, scope, __replSdkScopeNonce: id };
     },
     render: async (element, compiled, extra, compiler) => {
       /**
@@ -122,131 +189,22 @@ export async function compiler(config, api) {
         ...(args ? { args } : {}),
       });
 
-      const destroy = () => result.destroy();
-
-      /**
-       * @type {(() => void)[]}
-       */
-      const destroyables = [];
-
-      await Promise.all(
-        /** @type {unknown[]} */ (extra.codeBlocks).map(async (/** @type {unknown} */ info) => {
-          /** @type {Record<string, unknown>} */
-          const infoObj = /** @type {Record<string, unknown>} */ (info);
-
-          if (
-            !api.canCompile(
-              /** @type {string} */ (infoObj.format),
-              /** @type {string} */ (infoObj.flavor)
-            )
-          ) {
-            return;
-          }
-
-          const flavor = /** @type {string} */ (infoObj.flavor);
-          const hasScope =
-            flavor === 'ember' || infoObj.format === 'gjs' || infoObj.format === 'hbs';
-          const subRender = /** @type {{ element: HTMLElement, destroy: () => void }} */ (
-            await compiler.compile(
-              /** @type {string} */ (infoObj.format),
-              /** @type {string} */ (infoObj.code),
-              {
-                ...compiler.optionsFor(/** @type {string} */ (infoObj.format), flavor),
-                flavor: flavor,
-                // @ts-ignore
-                ...(hasScope
-                  ? {
-                      scope: extra.scope,
-                    }
-                  : {}),
-              }
-            )
-          );
-
-          const selector = `#${/** @type {string} */ (infoObj.placeholderId)}`;
-          const target = element.querySelector(selector);
-
-          assert(
-            `Could not find placeholder / target element (using selector: \`${selector}\`). ` +
-              `Could not render ${/** @type {string} */ (infoObj.format)} block.`,
-            target
-          );
-
-          destroyables.push(subRender.destroy);
-          target.appendChild(subRender.element);
-        })
-      );
-
       return () => {
-        for (const subDestroy of destroyables) {
-          subDestroy();
-        }
+        result.destroy();
 
-        destroy();
+        // Release the stashed scope so it's eligible for GC. The nonce is
+        // shape-typed on `extra` so we know exactly which slot to clear.
+        const nonce =
+          extra && typeof extra === 'object' && '__replSdkScopeNonce' in extra
+            ? /** @type {number} */ (extra.__replSdkScopeNonce)
+            : undefined;
+
+        if (typeof nonce === 'number') {
+          delete /** @type {Record<symbol, unknown>} */ (globalThis)[scopeKey(nonce)];
+        }
       };
     },
   };
 
   return gmdCompiler;
-
-  /**
-   * Build-time path: turn a parsed markdown result into a single ES module
-   * string that the host app's compiler can take to SSG-renderable output.
-   *
-   * Strategy:
-   *
-   *   1. For every live code block, recursively call the sub-compiler in
-   *      `renderToString: true` mode to get its babel-compiled module string.
-   *   2. Split each demo module into `{ imports, body }` and wrap the body in
-   *      `const Demo<N> = (() => { ...; return _component; })();`.
-   *   3. Replace the `<div id="placeholderId">…</div>` HTML placeholder for
-   *      each demo with a `<Demo<N> />` Glimmer component invocation.
-   *   4. Emit one module that imports `template` from
-   *      `@ember/template-compiler` (build-time), declares all the inlined
-   *      demo consts, and `export default`s a `template(prose, { scope })`
-   *      call referencing them.
-   *
-   * The output is *not* itself precompiled — it's a `.gjs`-shaped JS module
-   * that the host app's content-tag + babel pipeline will precompile to wire
-   * format, the same way it would for any other live `.gjs` file.
-   *
-   * @param {{ text: string, codeBlocks: Array<Record<string, unknown>> }} result
-   * @param {Record<string, unknown>} options
-   * @returns {Promise<{ source: string }>}
-   */
-  async function compileToSource(result, options) {
-    /** @type {Array<{ name: string, placeholderId: string, source: string }>} */
-    const demos = [];
-
-    let nth = 0;
-
-    for (const info of result.codeBlocks) {
-      const format = /** @type {string} */ (info.format);
-      const flavor = /** @type {string | undefined} */ (info.flavor);
-      const code = /** @type {string} */ (info.code);
-      const placeholderId = /** @type {string} */ (info.placeholderId);
-
-      if (!api.canCompile(format, flavor).result) {
-        continue;
-      }
-
-      nth++;
-
-      const demoName = `Demo${nth}`;
-      const subOptions = {
-        ...(options ?? {}),
-        flavor,
-        renderToString: true,
-      };
-
-      // `api` exposes `compileToSource` so a compiler can recursively ask for
-      // the build-time form of another compiler — gmd needs this to inline
-      // each live code block into the single emitted module.
-      const subResult = await api.compileToSource(format, code, subOptions);
-
-      demos.push({ name: demoName, placeholderId, source: subResult.source });
-    }
-
-    return { source: buildGmdModule({ prose: result.text, demos }) };
-  }
 }

--- a/packages/repl-sdk/src/compilers/ember/gmd.js
+++ b/packages/repl-sdk/src/compilers/ember/gmd.js
@@ -10,13 +10,16 @@ let elementId = 0;
 let scopeNonce = 0;
 
 /**
- * Symbol-keyed slot on `globalThis` where gmd's runtime path stashes the live
- * scope object so the emitted ES module can read it back at evaluation time.
+ * Slot on `globalThis` where gmd's runtime path stashes the live scope object
+ * so the emitted ES module can read it back at evaluation time. String-keyed
+ * (rather than Symbol-keyed) so TypeScript accepts the indexed access on
+ * `globalThis` without a cast — `globalThis[string]` is well-typed as
+ * `unknown`.
  *
  * @param {number} id
  */
 function scopeKey(id) {
-  return Symbol.for(`repl-sdk:gmd-scope:${id}`);
+  return `__replSdk__gmdScope__${id}`;
 }
 
 /**
@@ -106,11 +109,8 @@ export async function compiler(config, api) {
 
       let nth = 0;
 
-      for (const info of /** @type {Array<Record<string, unknown>>} */ (result.codeBlocks)) {
-        const format = /** @type {string} */ (info.format);
-        const flavor = /** @type {string | undefined} */ (info.flavor);
-        const code = /** @type {string} */ (info.code);
-        const placeholderId = /** @type {string} */ (info.placeholderId);
+      for (const info of result.codeBlocks) {
+        const { format, flavor, code, placeholderId } = info;
 
         if (!api.canCompile(format, flavor).result) continue;
 
@@ -144,14 +144,17 @@ export async function compiler(config, api) {
       const id = ++scopeNonce;
       const key = scopeKey(id);
 
-      /** @type {Record<symbol, unknown>} */ (globalThis)[key] = scope;
+      // `Reflect.set` writes the dynamic key onto `globalThis` without
+      // needing a cast — `typeof globalThis` doesn't have a string index
+      // signature, but `Reflect.set` accepts any `PropertyKey`.
+      Reflect.set(globalThis, key, scope);
 
       const source = buildGmdModule({
         prose: result.text,
         demos,
         templateModule: '@ember/template-compiler/runtime',
         scope: {
-          expression: `globalThis[Symbol.for('repl-sdk:gmd-scope:${id}')]`,
+          expression: `globalThis['${key}']`,
           keys: Object.keys(scope),
         },
       });
@@ -192,15 +195,16 @@ export async function compiler(config, api) {
       return () => {
         result.destroy();
 
-        // Release the stashed scope so it's eligible for GC. The nonce is
-        // shape-typed on `extra` so we know exactly which slot to clear.
-        const nonce =
-          extra && typeof extra === 'object' && '__replSdkScopeNonce' in extra
-            ? /** @type {number} */ (extra.__replSdkScopeNonce)
-            : undefined;
-
-        if (typeof nonce === 'number') {
-          delete /** @type {Record<symbol, unknown>} */ (globalThis)[scopeKey(nonce)];
+        // Release the stashed scope so it's eligible for GC. The nonce was
+        // attached to `extra` by `compile()` so we know exactly which slot
+        // to clear.
+        if (
+          extra &&
+          typeof extra === 'object' &&
+          '__replSdkScopeNonce' in extra &&
+          typeof extra.__replSdkScopeNonce === 'number'
+        ) {
+          Reflect.deleteProperty(globalThis, scopeKey(extra.__replSdkScopeNonce));
         }
       };
     },

--- a/packages/repl-sdk/src/compilers/ember/gmd.js
+++ b/packages/repl-sdk/src/compilers/ember/gmd.js
@@ -10,16 +10,16 @@ let elementId = 0;
 let scopeNonce = 0;
 
 /**
- * Slot on `globalThis` where gmd's runtime path stashes the live scope object
- * so the emitted ES module can read it back at evaluation time. String-keyed
- * (rather than Symbol-keyed) so TypeScript accepts the indexed access on
- * `globalThis` without a cast — `globalThis[string]` is well-typed as
- * `unknown`.
+ * Virtual ES module specifier under which gmd's runtime path registers the
+ * live scope object via `api.provide`. The emitted module then imports its
+ * scope from this specifier — Compiler's existing `manual:` resolver takes
+ * care of handing the registered value back, so individual compilers don't
+ * need to know how the bridge is implemented.
  *
  * @param {number} id
  */
-function scopeKey(id) {
-  return `__replSdk__gmdScope__${id}`;
+function scopeSpecifier(id) {
+  return `repl-sdk:gmd-scope:${id}`;
 }
 
 /**
@@ -86,10 +86,11 @@ export async function compiler(config, api) {
      *
      *   - How runtime scope crosses the source boundary. The build-time
      *     form can't reference a live JS object, so renderToString gets
-     *     an empty scope. The runtime form stashes the live scope object
-     *     on `globalThis[Symbol.for('repl-sdk:gmd-scope:N')]` and emits a
-     *     module that reads it back and destructures its keys into the
-     *     template's `scope: () => ({...})` call.
+     *     an empty scope. The runtime form registers the live scope object
+     *     behind a virtual ES module specifier via `api.provide` and emits
+     *     a module that `import * as __scope__ from '<specifier>'`. The
+     *     Compiler's existing `manual:` resolver handles the bridge, so
+     *     gmd never touches `globalThis` directly.
      */
     compile: async (text, options) => {
       const compileOptions = filterOptions(options);
@@ -141,25 +142,20 @@ export async function compiler(config, api) {
         return { source };
       }
 
-      const id = ++scopeNonce;
-      const key = scopeKey(id);
-
-      // `Reflect.set` writes the dynamic key onto `globalThis` without
-      // needing a cast — `typeof globalThis` doesn't have a string index
-      // signature, but `Reflect.set` accepts any `PropertyKey`.
-      Reflect.set(globalThis, key, scope);
+      const specifier = scopeSpecifier(++scopeNonce);
+      const unregisterScope = api.provide(specifier, scope);
 
       const source = buildGmdModule({
         prose: result.text,
         demos,
         templateModule: '@ember/template-compiler/runtime',
         scope: {
-          expression: `globalThis['${key}']`,
+          specifier,
           keys: Object.keys(scope),
         },
       });
 
-      return { compiled: source, ...result, scope, __replSdkScopeNonce: id };
+      return { compiled: source, ...result, scope, __replSdkUnregisterScope: unregisterScope };
     },
     render: async (element, compiled, extra, compiler) => {
       /**
@@ -195,16 +191,16 @@ export async function compiler(config, api) {
       return () => {
         result.destroy();
 
-        // Release the stashed scope so it's eligible for GC. The nonce was
-        // attached to `extra` by `compile()` so we know exactly which slot
-        // to clear.
+        // Release the registered scope so it's eligible for GC. `compile()`
+        // attached the unregister callback to `extra` so we know which
+        // entry to clear.
         if (
           extra &&
           typeof extra === 'object' &&
-          '__replSdkScopeNonce' in extra &&
-          typeof extra.__replSdkScopeNonce === 'number'
+          '__replSdkUnregisterScope' in extra &&
+          typeof extra.__replSdkUnregisterScope === 'function'
         ) {
-          Reflect.deleteProperty(globalThis, scopeKey(extra.__replSdkScopeNonce));
+          extra.__replSdkUnregisterScope();
         }
       };
     },

--- a/packages/repl-sdk/src/compilers/ember/gmd.js
+++ b/packages/repl-sdk/src/compilers/ember/gmd.js
@@ -58,27 +58,19 @@ export async function compiler(config, api) {
    */
   const gmdCompiler = {
     /**
-     * The runtime and renderToString paths share most of their work — both
-     * parse the markdown, recursively compile every live demo to a JS
-     * source string, then call `buildGmdModule` to inline those demos into
-     * a single `.gjs`-shaped module.
+     * Two shapes come out of here.
      *
-     * The only forks are:
+     * The runtime form returns a live component for the prose alone. Each
+     * live codefence stays a separate island that `render` compiles and
+     * mounts into its placeholder, so demos keep their own module, their own
+     * owner, and the caller's `scope` object by reference.
      *
-     *   - Which `@ember/template-compiler` to import. Runtime form uses
-     *     `/runtime` (the parse-and-compile-at-execution-time variant);
-     *     renderToString uses the build-time form so the host app's babel
-     *     pipeline can precompile the `template()` call to wire format.
-     *
-     *   - How runtime scope crosses the source boundary. The build-time
-     *     form can't reference a live JS object, so renderToString gets
-     *     an empty scope. The runtime form registers the live scope object
-     *     behind a virtual ES module specifier via `api.provide` and emits
-     *     a module that `import * as __scope__ from '<specifier>'`. The
-     *     Compiler's existing `manual:` resolver handles the bridge, so
-     *     gmd never touches `globalThis` directly.
+     * The renderToString form has no runtime to lean on: it has to hand back
+     * one self-contained module, so every demo is compiled to source and
+     * inlined. A live `scope` object cannot survive that trip, so build-time
+     * demos see an empty scope.
      */
-    compile: async (text, options, compileApi) => {
+    compile: async (text, options) => {
       const compileOptions = filterOptions(options);
       const result = await parseMarkdown(text, {
         remarkPlugins: [...userOptions.remarkPlugins, ...compileOptions.remarkPlugins],
@@ -91,77 +83,45 @@ export async function compiler(config, api) {
         getFlavorFromMeta,
       });
 
-      const renderToString = isRecord(options) && options.renderToString === true;
       const scope = {
         ...userOptions.scope,
         ...compileOptions.scope,
       };
 
-      /** @type {Array<{ name: string, placeholderId: string, source: string }>} */
-      const demos = [];
+      if (isRecord(options) && options.renderToString === true) {
+        /** @type {Array<{ name: string, placeholderId: string, source: string }>} */
+        const demos = [];
 
-      let nth = 0;
+        let nth = 0;
 
-      for (const info of result.codeBlocks) {
-        const { format, flavor, code, placeholderId } = info;
+        for (const info of result.codeBlocks) {
+          const { format, flavor, code, placeholderId } = info;
 
-        if (!api.canCompile(format, flavor).result) continue;
+          if (!api.canCompile(format, flavor).result) continue;
 
-        nth++;
+          nth++;
 
-        // On the runtime path each demo is inlined into this module, so it can
-        // read the live scope off the same `__scope__` namespace the prose
-        // uses. Handing the sub-compiler the same template module also keeps
-        // `mergeImports` from emitting two conflicting `template` bindings.
-        const sub = await api.compileToSource(format, code, {
-          ...(options ?? {}),
-          flavor,
-          ...(renderToString
-            ? {}
-            : {
-                inlineTemplateModule: '@ember/template-compiler/runtime',
-                inlineScopeKeys: Object.keys(scope),
-                inlineScopeNamespace: '__scope__',
-              }),
-        });
+          const sub = await api.compileToSource(format, code, {
+            ...(options ?? {}),
+            flavor,
+          });
 
-        demos.push({ name: `Demo${nth}`, placeholderId, source: sub.source });
+          demos.push({ name: `Demo${nth}`, placeholderId, source: sub.source });
+        }
+
+        const _babel = await api.tryResolve('@babel/standalone');
+        const babel = 'packages' in _babel ? _babel : _babel.default;
+
+        return { source: buildGmdModule({ babel, prose: result.text, demos }) };
       }
 
-      if (renderToString) {
-        const source = buildGmdModule({
-          prose: result.text,
-          demos,
-          templateModule: '@ember/template-compiler',
-          scope: null,
-        });
+      const { template } = await api.tryResolve('@ember/template-compiler/runtime');
 
-        return { source };
-      }
-
-      // `compileApi.provideScope` registers the live scope behind a
-      // Compiler-generated specifier and tracks it as part of this
-      // compile's lifecycle. The Compiler releases it when destroy fires;
-      // gmd doesn't need to track an unregister callback.
-      assert(
-        `gmd needs the per-compile API (3rd argument to compile) to provide its scope. ` +
-          `It looks like the Compiler did not pass one.`,
-        compileApi
-      );
-
-      const { specifier } = compileApi.provideScope(scope);
-
-      const source = buildGmdModule({
-        prose: result.text,
-        demos,
-        templateModule: '@ember/template-compiler/runtime',
-        scope: {
-          specifier,
-          keys: Object.keys(scope),
-        },
+      const component = template(result.text, {
+        scope: () => ({ ...scope }),
       });
 
-      return { compiled: source, ...result, scope };
+      return { compiled: component, ...result, scope };
     },
     render: async (element, compiled, extra, compiler) => {
       /**
@@ -194,7 +154,54 @@ export async function compiler(config, api) {
         ...(args ? { args } : {}),
       });
 
-      return () => result.destroy();
+      const destroy = () => result.destroy();
+
+      /**
+       * @type {(() => void)[]}
+       */
+      const destroyables = [];
+
+      await Promise.all(
+        /** @type {unknown[]} */ (extra.codeBlocks).map(async (/** @type {unknown} */ info) => {
+          /** @type {Record<string, unknown>} */
+          const infoObj = /** @type {Record<string, unknown>} */ (info);
+
+          const format = /** @type {string} */ (infoObj.format);
+          const flavor = /** @type {string} */ (infoObj.flavor);
+
+          if (!api.canCompile(format, flavor).result) {
+            return;
+          }
+
+          const hasScope = flavor === 'ember' || format === 'gjs' || format === 'hbs';
+          const subRender = await compiler.compile(format, /** @type {string} */ (infoObj.code), {
+            ...compiler.optionsFor(format, flavor),
+            flavor: flavor,
+            // @ts-ignore
+            ...(hasScope ? { scope: extra.scope } : {}),
+          });
+
+          const selector = `#${/** @type {string} */ (infoObj.placeholderId)}`;
+          const target = element.querySelector(selector);
+
+          assert(
+            `Could not find placeholder / target element (using selector: \`${selector}\`). ` +
+              `Could not render ${format} block.`,
+            target
+          );
+
+          destroyables.push(subRender.destroy);
+          target.appendChild(subRender.element);
+        })
+      );
+
+      return () => {
+        for (const subDestroy of destroyables) {
+          subDestroy();
+        }
+
+        destroy();
+      };
     },
   };
 

--- a/packages/repl-sdk/src/compilers/ember/gmd.js
+++ b/packages/repl-sdk/src/compilers/ember/gmd.js
@@ -109,8 +109,15 @@ export async function compiler(config, api) {
           demos.push({ name: `Demo${nth}`, placeholderId, source: sub.source });
         }
 
-        const _babel = await api.tryResolve('@babel/standalone');
-        const babel = 'packages' in _babel ? _babel : _babel.default;
+        // Merging demo modules is the only thing here that needs an AST, so a
+        // document with no live demos never asks the host for babel.
+        let babel;
+
+        if (demos.length) {
+          const resolved = await api.tryResolve('@babel/standalone');
+
+          babel = 'packages' in resolved ? resolved : resolved.default;
+        }
 
         return { source: buildGmdModule({ babel, prose: result.text, demos }) };
       }

--- a/packages/repl-sdk/src/compilers/ember/hbs.js
+++ b/packages/repl-sdk/src/compilers/ember/hbs.js
@@ -26,6 +26,23 @@ export async function compiler(config, api) {
    */
   const hbsCompiler = {
     compile: async (text, options) => {
+      if (isRecord(options) && options.renderToString) {
+        // Build-time form: emit a JS module that imports `template` from the
+        // build-time template-compiler. The host app's content-tag/babel
+        // pipeline will precompile the `template(...)` call to wire format.
+        //
+        // We can't serialize a runtime `scope` object, so renderToString
+        // ignores `options.scope` — any identifiers the hbs body references
+        // must be in scope at the *consumer* (e.g. provided by the gmd
+        // wrapper's own imports/locals).
+        const source =
+          `import { template } from '@ember/template-compiler';\n` +
+          `const _component = template(${JSON.stringify(text)}, { scope: () => ({}) });\n` +
+          `export default _component;\n`;
+
+        return source;
+      }
+
       const { template } = await api.tryResolve('@ember/template-compiler/runtime');
 
       const component = template(text, {

--- a/packages/repl-sdk/src/compilers/ember/hbs.js
+++ b/packages/repl-sdk/src/compilers/ember/hbs.js
@@ -31,13 +31,26 @@ export async function compiler(config, api) {
         // build-time template-compiler. The host app's content-tag/babel
         // pipeline will precompile the `template(...)` call to wire format.
         //
-        // We can't serialize a runtime `scope` object, so renderToString
-        // ignores `options.scope` — any identifiers the hbs body references
-        // must be in scope at the *consumer* (e.g. provided by the gmd
-        // wrapper's own imports/locals).
+        // A runtime `scope` object can't be serialized into source, so the
+        // standalone form emits an empty scope. When gmd inlines this module
+        // into a parent that imports a live scope namespace, it passes that
+        // namespace and the keys on it, and reading through it here is what
+        // keeps a live codefence working with top-level scope.
+        const templateModule =
+          typeof options.inlineTemplateModule === 'string'
+            ? options.inlineTemplateModule
+            : '@ember/template-compiler';
+        const scopeKeys = Array.isArray(options.inlineScopeKeys) ? options.inlineScopeKeys : [];
+        const namespace =
+          typeof options.inlineScopeNamespace === 'string' ? options.inlineScopeNamespace : null;
+        const scopeBody =
+          namespace && scopeKeys.length
+            ? `{ ${scopeKeys.map((key) => `${key}: ${namespace}.${key}`).join(', ')} }`
+            : `{}`;
+
         const source =
-          `import { template } from '@ember/template-compiler';\n` +
-          `const _component = template(${JSON.stringify(text)}, { scope: () => ({}) });\n` +
+          `import { template } from '${templateModule}';\n` +
+          `const _component = template(${JSON.stringify(text)}, { scope: () => (${scopeBody}) });\n` +
           `export default _component;\n`;
 
         return source;

--- a/packages/repl-sdk/src/compilers/ember/hbs.js
+++ b/packages/repl-sdk/src/compilers/ember/hbs.js
@@ -31,26 +31,12 @@ export async function compiler(config, api) {
         // build-time template-compiler. The host app's content-tag/babel
         // pipeline will precompile the `template(...)` call to wire format.
         //
-        // A runtime `scope` object can't be serialized into source, so the
-        // standalone form emits an empty scope. When gmd inlines this module
-        // into a parent that imports a live scope namespace, it passes that
-        // namespace and the keys on it, and reading through it here is what
-        // keeps a live codefence working with top-level scope.
-        const templateModule =
-          typeof options.inlineTemplateModule === 'string'
-            ? options.inlineTemplateModule
-            : '@ember/template-compiler';
-        const scopeKeys = Array.isArray(options.inlineScopeKeys) ? options.inlineScopeKeys : [];
-        const namespace =
-          typeof options.inlineScopeNamespace === 'string' ? options.inlineScopeNamespace : null;
-        const scopeBody =
-          namespace && scopeKeys.length
-            ? `{ ${scopeKeys.map((key) => `${key}: ${namespace}.${key}`).join(', ')} }`
-            : `{}`;
-
+        // A runtime `scope` object cannot be serialized into source, so the
+        // emitted module declares an empty scope. Identifiers the hbs body
+        // references have to be in scope at the consumer instead.
         const source =
-          `import { template } from '${templateModule}';\n` +
-          `const _component = template(${JSON.stringify(text)}, { scope: () => (${scopeBody}) });\n` +
+          `import { template } from '@ember/template-compiler';\n` +
+          `const _component = template(${JSON.stringify(text)}, { scope: () => ({}) });\n` +
           `export default _component;\n`;
 
         return source;

--- a/packages/repl-sdk/src/compilers/markdown.js
+++ b/packages/repl-sdk/src/compilers/markdown.js
@@ -89,13 +89,15 @@ export const md = {
             }
 
             const flavor = /** @type {string} */ (infoObj.flavor);
-            const subRender = await compiler.compile(
-              /** @type {string} */ (infoObj.format),
-              /** @type {string} */ (infoObj.code),
-              {
-                ...compiler.optionsFor(/** @type {string} */ (infoObj.format), flavor),
-                flavor: flavor,
-              }
+            const subRender = /** @type {{ element: HTMLElement, destroy: () => void }} */ (
+              await compiler.compile(
+                /** @type {string} */ (infoObj.format),
+                /** @type {string} */ (infoObj.code),
+                {
+                  ...compiler.optionsFor(/** @type {string} */ (infoObj.format), flavor),
+                  flavor: flavor,
+                }
+              )
             );
 
             const selector = `#${/** @type {string} */ (infoObj.placeholderId)}`;

--- a/packages/repl-sdk/src/compilers/markdown.js
+++ b/packages/repl-sdk/src/compilers/markdown.js
@@ -89,15 +89,13 @@ export const md = {
             }
 
             const flavor = /** @type {string} */ (infoObj.flavor);
-            const subRender = /** @type {{ element: HTMLElement, destroy: () => void }} */ (
-              await compiler.compile(
-                /** @type {string} */ (infoObj.format),
-                /** @type {string} */ (infoObj.code),
-                {
-                  ...compiler.optionsFor(/** @type {string} */ (infoObj.format), flavor),
-                  flavor: flavor,
-                }
-              )
+            const subRender = await compiler.compile(
+              /** @type {string} */ (infoObj.format),
+              /** @type {string} */ (infoObj.code),
+              {
+                ...compiler.optionsFor(/** @type {string} */ (infoObj.format), flavor),
+                flavor: flavor,
+              }
             );
 
             const selector = `#${/** @type {string} */ (infoObj.placeholderId)}`;

--- a/packages/repl-sdk/src/compilers/markdown/parse.d.ts
+++ b/packages/repl-sdk/src/compilers/markdown/parse.d.ts
@@ -1,14 +1,28 @@
 import type { InternalOptions } from './types';
 
+/**
+ * One live code fence's worth of information collected during the parse pass.
+ * Mirrors what `liveCodeExtraction` pushes onto `file.data.liveCode`.
+ */
+export interface LiveCodeBlock {
+  /** Language id from the code fence (e.g. `gjs`, `hbs`, `python`). */
+  format: string;
+  /** Optional flavor parsed from the meta (e.g. `ember`, `react`). */
+  flavor: string | undefined;
+  /** The fence body, trimmed. */
+  code: string;
+  /** Stable id used by the placeholder `<div id="…">` in the rendered HTML. */
+  placeholderId: string;
+  /** Raw meta string from the fence. */
+  meta: string | undefined;
+}
+
 export function parseMarkdown(
   input: string,
   options: InternalOptions
 ): Promise<{
   text: string;
-  codeBlocks: Array<{
-    lang: string;
-    format: string;
-    code: string;
-    name: string;
-  }>;
+  codeBlocks: LiveCodeBlock[];
 }>;
+
+export function buildCompiler(options: InternalOptions): unknown;

--- a/packages/repl-sdk/src/index.d.ts
+++ b/packages/repl-sdk/src/index.d.ts
@@ -15,15 +15,9 @@ export class Compiler {
     options?: {
       flavor?: string;
       fileName?: string;
-      /**
-       * When true, returns `{ source: string }` instead of evaluating and
-       * rendering. Most callers should use {@link Compiler.compileToSource}
-       * instead.
-       */
-      renderToString?: boolean;
       [key: string]: unknown;
     }
-  ): Promise<{ element: HTMLElement; destroy: () => void } | { source: string }>;
+  ): Promise<{ element: HTMLElement; destroy: () => void }>;
 
   /**
    * Build-time variant of {@link Compiler.compile}: returns the compiled JS

--- a/packages/repl-sdk/src/index.d.ts
+++ b/packages/repl-sdk/src/index.d.ts
@@ -15,8 +15,29 @@ export class Compiler {
     options?: {
       flavor?: string;
       fileName?: string;
+      /**
+       * When true, returns `{ source: string }` instead of evaluating and
+       * rendering. Most callers should use {@link Compiler.compileToSource}
+       * instead.
+       */
+      renderToString?: boolean;
+      [key: string]: unknown;
     }
-  ): Promise<{ element: HTMLElement; destroy: () => void }>;
+  ): Promise<{ element: HTMLElement; destroy: () => void } | { source: string }>;
+
+  /**
+   * Build-time variant of {@link Compiler.compile}: returns the compiled JS
+   * module source as a string instead of evaluating and rendering.
+   *
+   * Intended for SSG / pre-rendering pipelines that want to hand the
+   * compiled output to their own bundler rather than evaluate it in the
+   * browser at boot.
+   */
+  compileToSource(
+    format: string,
+    text: string,
+    options?: Record<string, unknown>
+  ): Promise<{ source: string }>;
 
   optionsFor(format: string, flavor?: string): Omit<CompilerConfig, 'compiler'>;
 

--- a/packages/repl-sdk/src/index.d.ts
+++ b/packages/repl-sdk/src/index.d.ts
@@ -22,8 +22,29 @@ export class Compiler {
     options?: {
       flavor?: string;
       fileName?: string;
+      /**
+       * When true, returns `{ source: string }` instead of evaluating and
+       * rendering. Most callers should use {@link Compiler.compileToSource}
+       * instead.
+       */
+      renderToString?: boolean;
+      [key: string]: unknown;
     }
-  ): Promise<{ element: HTMLElement; destroy: () => void }>;
+  ): Promise<{ element: HTMLElement; destroy: () => void } | { source: string }>;
+
+  /**
+   * Build-time variant of {@link Compiler.compile}: returns the compiled JS
+   * module source as a string instead of evaluating and rendering.
+   *
+   * Intended for SSG / pre-rendering pipelines that want to hand the
+   * compiled output to their own bundler rather than evaluate it in the
+   * browser at boot.
+   */
+  compileToSource(
+    format: string,
+    text: string,
+    options?: Record<string, unknown>
+  ): Promise<{ source: string }>;
 
   optionsFor(format: string, flavor?: string): Omit<CompilerConfig, 'compiler'>;
 

--- a/packages/repl-sdk/src/index.d.ts
+++ b/packages/repl-sdk/src/index.d.ts
@@ -22,15 +22,9 @@ export class Compiler {
     options?: {
       flavor?: string;
       fileName?: string;
-      /**
-       * When true, returns `{ source: string }` instead of evaluating and
-       * rendering. Most callers should use {@link Compiler.compileToSource}
-       * instead.
-       */
-      renderToString?: boolean;
       [key: string]: unknown;
     }
-  ): Promise<{ element: HTMLElement; destroy: () => void } | { source: string }>;
+  ): Promise<{ element: HTMLElement; destroy: () => void }>;
 
   /**
    * Build-time variant of {@link Compiler.compile}: returns the compiled JS

--- a/packages/repl-sdk/src/index.js
+++ b/packages/repl-sdk/src/index.js
@@ -370,6 +370,22 @@ export class Compiler {
   }
 
   /**
+   * Build-time variant of {@link Compiler.compile}: returns the compiled JS
+   * module source as a string instead of evaluating and rendering. Equivalent
+   * to `compile(format, text, { ...options, renderToString: true })`.
+   *
+   * @param {string} format
+   * @param {string} text
+   * @param {Record<string, unknown>} [options]
+   * @returns {Promise<{ source: string }>}
+   */
+  async compileToSource(format, text, options = {}) {
+    return /** @type {{ source: string }} */ (
+      await this.compile(format, text, { ...options, renderToString: true })
+    );
+  }
+
+  /**
    * Build-time variant of `#compile`: returns the compiled JavaScript source
    * as a string rather than loading it via a blob URL and rendering.
    *
@@ -725,14 +741,9 @@ export class Compiler {
      * string instead of rendering. Exposed on the public API so compilers
      * (e.g. `gmd`) can recursively ask other compilers to renderToString.
      *
-     * @param {string} format
-     * @param {string} text
-     * @param {Record<string, unknown>} [options]
+     * @param {Parameters<Compiler['compileToSource']>} args
      */
-    compileToSource: (format, text, options = {}) =>
-      /** @type {Promise<{ source: string }>} */ (
-        this.compile(format, text, { ...options, renderToString: true })
-      ),
+    compileToSource: (...args) => this.compileToSource(...args),
     /**
      * @param {Parameters<Compiler['optionsFor']>} args
      */

--- a/packages/repl-sdk/src/index.js
+++ b/packages/repl-sdk/src/index.js
@@ -420,7 +420,7 @@ export class Compiler {
       return { source: compiled };
     }
 
-    if (compiled && typeof /** @type {{source?: unknown}} */ (compiled).source === 'string') {
+    if (compiled && typeof (/** @type {{source?: unknown}} */ (compiled).source) === 'string') {
       return /** @type {{source: string}} */ (compiled);
     }
 

--- a/packages/repl-sdk/src/index.js
+++ b/packages/repl-sdk/src/index.js
@@ -345,34 +345,19 @@ export class Compiler {
   /**
    * @param {string} format
    * @param {string} text
-   * @param {{ fileName?: string, flavor?: string, args?: Record<string, unknown>, renderToString?: boolean, [key: string]: unknown }} [ options ]
-   * @returns {Promise<{ element: HTMLElement, destroy: () => void } | { source: string }>}
+   * @param {{ fileName?: string, flavor?: string, args?: Record<string, unknown>, [key: string]: unknown }} [ options ]
+   * @returns {Promise<{ element: HTMLElement, destroy: () => void }>}
    */
   async compile(format, text, options = {}) {
-    this.#announce('info', `Compiling ${format}`);
-
-    try {
-      if (options.renderToString) {
-        return await this.#compileToSource(format, text, options);
-      }
-
-      return await this.#compile(format, text, options);
-    } catch (e) {
-      // for on.log usage
-      const message = e instanceof Error ? e.message : e;
-
-      this.#announce('error', String(message));
-
-      // Don't hide errors!
-      this.#error(e);
-      throw e;
-    }
+    return this.#runCompile(this.#compile, format, text, options);
   }
 
   /**
    * Build-time variant of {@link Compiler.compile}: returns the compiled JS
-   * module source as a string instead of evaluating and rendering. Equivalent
-   * to `compile(format, text, { ...options, renderToString: true })`.
+   * module source as a string instead of evaluating and rendering. Each
+   * configured compiler sees `renderToString: true` on its options and is
+   * expected to emit a source string (`string` or `{ source: string, … }`)
+   * rather than a runtime component.
    *
    * @param {string} format
    * @param {string} text
@@ -380,9 +365,34 @@ export class Compiler {
    * @returns {Promise<{ source: string }>}
    */
   async compileToSource(format, text, options = {}) {
-    return /** @type {{ source: string }} */ (
-      await this.compile(format, text, { ...options, renderToString: true })
-    );
+    return this.#runCompile(this.#compileToSource, format, text, options);
+  }
+
+  /**
+   * Shared wrapper for `compile` / `compileToSource`: announces lifecycle
+   * messages and forwards any thrown error through `on.log` before letting
+   * it propagate. Both public entry points share this so the user-visible
+   * logging is identical whether they're rendering or just getting source.
+   *
+   * @template T
+   * @param {(format: string, text: string, options: Record<string, unknown>) => Promise<T>} impl
+   * @param {string} format
+   * @param {string} text
+   * @param {Record<string, unknown>} options
+   * @returns {Promise<T>}
+   */
+  async #runCompile(impl, format, text, options) {
+    this.#announce('info', `Compiling ${format}`);
+
+    try {
+      return await impl.call(this, format, text, options);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : e;
+
+      this.#announce('error', String(message));
+      this.#error(e);
+      throw e;
+    }
   }
 
   /**
@@ -405,29 +415,34 @@ export class Compiler {
    * @returns {Promise<{ source: string }>}
    */
   async #compileToSource(format, text, options) {
-    /** @type {Record<string, unknown>} */
-    const opts = { ...options, renderToString: true };
+    const flavor = typeof options.flavor === 'string' ? options.flavor : undefined;
+    const fileName = typeof options.fileName === 'string' ? options.fileName : `dynamic.${format}`;
+    const opts = { ...options, fileName, renderToString: true };
 
-    opts.fileName ||= `dynamic.${format}`;
-
-    const compiler = await this.#getCompiler(
-      format,
-      /** @type {string | undefined} */ (opts.flavor)
-    );
+    const compiler = await this.#getCompiler(format, flavor);
     const compiled = await compiler.compile(text, opts);
 
     if (typeof compiled === 'string') {
       return { source: compiled };
     }
 
-    if (compiled && typeof (/** @type {{source?: unknown}} */ (compiled).source) === 'string') {
-      return /** @type {{source: string}} */ (compiled);
+    if (
+      compiled !== null &&
+      typeof compiled === 'object' &&
+      'source' in compiled &&
+      typeof compiled.source === 'string'
+    ) {
+      return { source: compiled.source };
     }
+
+    const shape =
+      compiled !== null && typeof compiled === 'object'
+        ? Object.keys(compiled).join(', ')
+        : typeof compiled;
 
     throw new Error(
       `Compiler for format '${format}' was asked to renderToString but returned ` +
-        `${typeof compiled === 'object' ? Object.keys(/** @type {object} */ (compiled)).join(', ') : typeof compiled} ` +
-        `instead of a source string.`
+        `${shape} instead of a source string.`
     );
   }
 

--- a/packages/repl-sdk/src/index.js
+++ b/packages/repl-sdk/src/index.js
@@ -345,13 +345,17 @@ export class Compiler {
   /**
    * @param {string} format
    * @param {string} text
-   * @param {{ fileName?: string, flavor?: string, args?: Record<string, unknown>, [key: string]: unknown }} [ options ]
-   * @returns {Promise<{ element: HTMLElement, destroy: () => void }>}
+   * @param {{ fileName?: string, flavor?: string, args?: Record<string, unknown>, renderToString?: boolean, [key: string]: unknown }} [ options ]
+   * @returns {Promise<{ element: HTMLElement, destroy: () => void } | { source: string }>}
    */
   async compile(format, text, options = {}) {
     this.#announce('info', `Compiling ${format}`);
 
     try {
+      if (options.renderToString) {
+        return await this.#compileToSource(format, text, options);
+      }
+
       return await this.#compile(format, text, options);
     } catch (e) {
       // for on.log usage
@@ -363,6 +367,52 @@ export class Compiler {
       this.#error(e);
       throw e;
     }
+  }
+
+  /**
+   * Build-time variant of `#compile`: returns the compiled JavaScript source
+   * as a string rather than loading it via a blob URL and rendering.
+   *
+   * Useful for SSG / pre-rendering pipelines that want to take the compiled
+   * output of a live demo (or a `gmd` document containing live demos) and
+   * hand it to their own bundler instead of evaluating it in the browser.
+   *
+   * Each compiler is asked to `compile(text, { renderToString: true, ... })`
+   * — it's the compiler's responsibility to honor the flag and return a
+   * source string (`string` or `{ source: string }`). The `gmd` compiler
+   * recursively threads `renderToString` through its per-format dispatch and
+   * inlines every demo into one self-contained module.
+   *
+   * @param {string} format
+   * @param {string} text
+   * @param {Record<string, unknown>} options
+   * @returns {Promise<{ source: string }>}
+   */
+  async #compileToSource(format, text, options) {
+    /** @type {Record<string, unknown>} */
+    const opts = { ...options, renderToString: true };
+
+    opts.fileName ||= `dynamic.${format}`;
+
+    const compiler = await this.#getCompiler(
+      format,
+      /** @type {string | undefined} */ (opts.flavor)
+    );
+    const compiled = await compiler.compile(text, opts);
+
+    if (typeof compiled === 'string') {
+      return { source: compiled };
+    }
+
+    if (compiled && typeof /** @type {{source?: unknown}} */ (compiled).source === 'string') {
+      return /** @type {{source: string}} */ (compiled);
+    }
+
+    throw new Error(
+      `Compiler for format '${format}' was asked to renderToString but returned ` +
+        `${typeof compiled === 'object' ? Object.keys(/** @type {object} */ (compiled)).join(', ') : typeof compiled} ` +
+        `instead of a source string.`
+    );
   }
 
   /**
@@ -670,6 +720,19 @@ export class Compiler {
      * @param {Parameters<Compiler['compile']>} args
      */
     compile: (...args) => this.compile(...args),
+    /**
+     * Build-time variant of `compile` — returns the compiled JS source as a
+     * string instead of rendering. Exposed on the public API so compilers
+     * (e.g. `gmd`) can recursively ask other compilers to renderToString.
+     *
+     * @param {string} format
+     * @param {string} text
+     * @param {Record<string, unknown>} [options]
+     */
+    compileToSource: (format, text, options = {}) =>
+      /** @type {Promise<{ source: string }>} */ (
+        this.compile(format, text, { ...options, renderToString: true })
+      ),
     /**
      * @param {Parameters<Compiler['optionsFor']>} args
      */

--- a/packages/repl-sdk/src/index.js
+++ b/packages/repl-sdk/src/index.js
@@ -759,6 +759,39 @@ export class Compiler {
      * @param {Parameters<Compiler['compileToSource']>} args
      */
     compileToSource: (...args) => this.compileToSource(...args),
+
+    /**
+     * Register a JS value to be resolvable as an ES module under a virtual
+     * import specifier. Returns a cleanup function that unregisters it.
+     *
+     * Compilers use this when their emitted source needs to reach back to a
+     * runtime value that can't be serialized into a module string —
+     * typically a live scope object. The emitted source can then
+     * `import * as scope from '${specifier}'` and rely on the compiler's
+     * resolver to fetch the value, instead of every compiler hand-rolling
+     * its own `globalThis` namespace.
+     *
+     * Under the hood this layers on the same `manual:` resolver +
+     * `cache.resolves` machinery the Compiler already uses for caller-
+     * supplied `options.resolve` entries.
+     *
+     * @param {string} specifier
+     * @param {unknown} value
+     * @returns {() => void}
+     */
+    provide: (specifier, value) => {
+      this.#options.resolve ??= {};
+      this.#options.resolve[specifier] = value;
+      cache.resolves[specifier] = value;
+
+      return () => {
+        if (this.#options.resolve) {
+          delete this.#options.resolve[specifier];
+        }
+
+        delete cache.resolves[specifier];
+      };
+    },
     /**
      * @param {Parameters<Compiler['optionsFor']>} args
      */

--- a/packages/repl-sdk/src/index.js
+++ b/packages/repl-sdk/src/index.js
@@ -22,17 +22,21 @@ export const defaults = {
   formats: compilers,
 };
 
+/**
+ * Namespaces the virtual specifiers `api.provideScope` hands back.
+ *
+ * Module-scoped, not per-Compiler: the es-module-shim's registry is global to
+ * the page and caches each specifier's exports the first time it is fetched.
+ * A per-instance counter restarts at 1 for every new Compiler, so a second
+ * Compiler would hand out a specifier whose module was already cached against
+ * an earlier compile's scope keys, and every key added since would resolve to
+ * undefined.
+ */
+let scopeCounter = 0;
+
 export class Compiler {
   /** @type {Options} */
   #options;
-
-  /**
-   * Monotonic counter that namespaces the virtual specifiers
-   * `api.provideScope` hands back. Lives on the Compiler so concurrent
-   * compiles (or repeated compiles of the same source) never collide on
-   * the same `cache.resolves` entry.
-   */
-  #scopeCounter = 0;
 
   /**
    * Options may be passed to the compiler to add to its behavior.
@@ -65,7 +69,7 @@ export class Compiler {
     const registry = new Set();
 
     const provideScope = (/** @type {unknown} */ value) => {
-      const specifier = `repl-sdk:scope:${++this.#scopeCounter}`;
+      const specifier = `repl-sdk:scope:${++scopeCounter}`;
 
       this.#options.resolve ??= {};
       this.#options.resolve[specifier] = value;
@@ -588,6 +592,7 @@ export class Compiler {
 
     try {
       const asBlobUrl = textToBlobUrl(compiledText);
+
       // @ts-ignore
       ({ default: defaultExport } = await shimmedImport(/* @vite-ignore */ asBlobUrl));
     } catch (e) {

--- a/packages/repl-sdk/src/index.js
+++ b/packages/repl-sdk/src/index.js
@@ -347,13 +347,17 @@ export class Compiler {
   /**
    * @param {string} format
    * @param {string} text
-   * @param {{ fileName?: string, flavor?: string, args?: Record<string, unknown>, [key: string]: unknown }} [ options ]
-   * @returns {Promise<{ element: HTMLElement, destroy: () => void }>}
+   * @param {{ fileName?: string, flavor?: string, args?: Record<string, unknown>, renderToString?: boolean, [key: string]: unknown }} [ options ]
+   * @returns {Promise<{ element: HTMLElement, destroy: () => void } | { source: string }>}
    */
   async compile(format, text, options = {}) {
     this.#announce('info', `Compiling ${format}`);
 
     try {
+      if (options.renderToString) {
+        return await this.#compileToSource(format, text, options);
+      }
+
       return await this.#compile(format, text, options);
     } catch (e) {
       // for on.log usage
@@ -363,6 +367,52 @@ export class Compiler {
       this.#error(e);
       throw e;
     }
+  }
+
+  /**
+   * Build-time variant of `#compile`: returns the compiled JavaScript source
+   * as a string rather than loading it via a blob URL and rendering.
+   *
+   * Useful for SSG / pre-rendering pipelines that want to take the compiled
+   * output of a live demo (or a `gmd` document containing live demos) and
+   * hand it to their own bundler instead of evaluating it in the browser.
+   *
+   * Each compiler is asked to `compile(text, { renderToString: true, ... })`
+   * — it's the compiler's responsibility to honor the flag and return a
+   * source string (`string` or `{ source: string }`). The `gmd` compiler
+   * recursively threads `renderToString` through its per-format dispatch and
+   * inlines every demo into one self-contained module.
+   *
+   * @param {string} format
+   * @param {string} text
+   * @param {Record<string, unknown>} options
+   * @returns {Promise<{ source: string }>}
+   */
+  async #compileToSource(format, text, options) {
+    /** @type {Record<string, unknown>} */
+    const opts = { ...options, renderToString: true };
+
+    opts.fileName ||= `dynamic.${format}`;
+
+    const compiler = await this.#getCompiler(
+      format,
+      /** @type {string | undefined} */ (opts.flavor)
+    );
+    const compiled = await compiler.compile(text, opts);
+
+    if (typeof compiled === 'string') {
+      return { source: compiled };
+    }
+
+    if (compiled && typeof /** @type {{source?: unknown}} */ (compiled).source === 'string') {
+      return /** @type {{source: string}} */ (compiled);
+    }
+
+    throw new Error(
+      `Compiler for format '${format}' was asked to renderToString but returned ` +
+        `${typeof compiled === 'object' ? Object.keys(/** @type {object} */ (compiled)).join(', ') : typeof compiled} ` +
+        `instead of a source string.`
+    );
   }
 
   /**
@@ -670,6 +720,19 @@ export class Compiler {
      * @param {Parameters<Compiler['compile']>} args
      */
     compile: (...args) => this.compile(...args),
+    /**
+     * Build-time variant of `compile` — returns the compiled JS source as a
+     * string instead of rendering. Exposed on the public API so compilers
+     * (e.g. `gmd`) can recursively ask other compilers to renderToString.
+     *
+     * @param {string} format
+     * @param {string} text
+     * @param {Record<string, unknown>} [options]
+     */
+    compileToSource: (format, text, options = {}) =>
+      /** @type {Promise<{ source: string }>} */ (
+        this.compile(format, text, { ...options, renderToString: true })
+      ),
     /**
      * @param {Parameters<Compiler['optionsFor']>} args
      */

--- a/packages/repl-sdk/src/index.js
+++ b/packages/repl-sdk/src/index.js
@@ -27,6 +27,14 @@ export class Compiler {
   #options;
 
   /**
+   * Monotonic counter that namespaces the virtual specifiers
+   * `api.provideScope` hands back. Lives on the Compiler so concurrent
+   * compiles (or repeated compiles of the same source) never collide on
+   * the same `cache.resolves` entry.
+   */
+  #scopeCounter = 0;
+
+  /**
    * Options may be passed to the compiler to add to its behavior.
    * @param {Partial<Options>} options
    */
@@ -37,6 +45,54 @@ export class Compiler {
     STABLE_REFERENCE.fetch = this.#fetch;
 
     window.addEventListener('unhandledrejection', this.#handleUnhandledRejection);
+  }
+
+  /**
+   * Build a per-compile API: the same shape as the shared `PublicMethods`
+   * but with an extra `provideScope(value)` method whose registrations are
+   * tracked by `registry`. After the compile (and any render it triggers)
+   * finishes, the Compiler calls `dispose()` to release everything in
+   * `registry` — so individual compilers never have to remember to clean
+   * up the values they expose through `provideScope`.
+   *
+   * @returns {{
+   *   api: import('./types.ts').CompileAPI,
+   *   dispose: () => void,
+   * }}
+   */
+  #createCompileScope() {
+    /** @type {Set<string>} */
+    const registry = new Set();
+
+    const provideScope = (/** @type {unknown} */ value) => {
+      const specifier = `repl-sdk:scope:${++this.#scopeCounter}`;
+
+      this.#options.resolve ??= {};
+      this.#options.resolve[specifier] = value;
+      cache.resolves[specifier] = value;
+      registry.add(specifier);
+
+      return { specifier };
+    };
+
+    const dispose = () => {
+      for (const specifier of registry) {
+        if (this.#options.resolve) {
+          delete this.#options.resolve[specifier];
+        }
+
+        delete cache.resolves[specifier];
+      }
+
+      registry.clear();
+    };
+
+    const api = /** @type {import('./types.ts').CompileAPI} */ ({
+      ...this.#nestedPublicAPI,
+      provideScope,
+    });
+
+    return { api, dispose };
   }
 
   /**
@@ -423,30 +479,44 @@ export class Compiler {
     const opts = { ...options, fileName, renderToString: true };
 
     const compiler = await this.#getCompiler(format, flavor);
-    const compiled = await compiler.compile(text, opts);
+    const { api, dispose } = this.#createCompileScope();
 
-    if (typeof compiled === 'string') {
-      return { source: compiled };
+    try {
+      const compiled = await compiler.compile(text, opts, api);
+
+      if (typeof compiled === 'string') {
+        return { source: compiled };
+      }
+
+      if (
+        compiled !== null &&
+        typeof compiled === 'object' &&
+        'source' in compiled &&
+        typeof compiled.source === 'string'
+      ) {
+        return { source: compiled.source };
+      }
+
+      const shape =
+        compiled !== null && typeof compiled === 'object'
+          ? Object.keys(compiled).join(', ')
+          : typeof compiled;
+
+      throw new Error(
+        `Compiler for format '${format}' was asked to renderToString but returned ` +
+          `${shape} instead of a source string.`
+      );
+    } finally {
+      // renderToString never renders, so anything `provideScope` registered
+      // during this compile has no rendered-element lifecycle to attach to.
+      // Release it immediately — the emitted source string was constructed
+      // with the scope inlined as a virtual specifier reference, but the
+      // *value* behind that specifier is only meaningful while this compile
+      // is in flight (e.g. for gmd's nested renderToString sub-compiles to
+      // share helpers with their parent). The caller's bundler resolves the
+      // specifier statically at build time; runtime lookup is never used.
+      dispose();
     }
-
-    if (
-      compiled !== null &&
-      typeof compiled === 'object' &&
-      'source' in compiled &&
-      typeof compiled.source === 'string'
-    ) {
-      return { source: compiled.source };
-    }
-
-    const shape =
-      compiled !== null && typeof compiled === 'object'
-        ? Object.keys(compiled).join(', ')
-        : typeof compiled;
-
-    throw new Error(
-      `Compiler for format '${format}' was asked to renderToString but returned ` +
-        `${shape} instead of a source string.`
-    );
   }
 
   /**
@@ -468,7 +538,16 @@ export class Compiler {
     this.#log('[compile] compiling');
 
     const compiler = await this.#getCompiler(format, opts.flavor);
-    const compiled = await compiler.compile(text, opts);
+    const { api, dispose } = this.#createCompileScope();
+
+    let compiled;
+
+    try {
+      compiled = await compiler.compile(text, opts, api);
+    } catch (e) {
+      dispose();
+      throw e;
+    }
 
     let compiledText = 'export default "failed to compile"';
     let extras = { compiled: '' };
@@ -492,24 +571,42 @@ export class Compiler {
         extras = compiled;
       }
 
-      return this.#render(compiler, value, {
-        ...extras,
-        compiled: value,
-        ...(opts.args ? { args: opts.args } : {}),
-      });
+      return this.#render(
+        compiler,
+        value,
+        {
+          ...extras,
+          compiled: value,
+          ...(opts.args ? { args: opts.args } : {}),
+        },
+        api,
+        dispose
+      );
     }
 
-    const asBlobUrl = textToBlobUrl(compiledText);
+    let defaultExport;
 
-    // @ts-ignore
-    const { default: defaultExport } = await shimmedImport(/* @vite-ignore */ asBlobUrl);
+    try {
+      const asBlobUrl = textToBlobUrl(compiledText);
+      // @ts-ignore
+      ({ default: defaultExport } = await shimmedImport(/* @vite-ignore */ asBlobUrl));
+    } catch (e) {
+      dispose();
+      throw e;
+    }
 
     this.#log('[compile] preparing to render', defaultExport, extras);
 
-    return this.#render(compiler, defaultExport, {
-      ...extras,
-      ...(opts.args ? { args: opts.args } : {}),
-    });
+    return this.#render(
+      compiler,
+      defaultExport,
+      {
+        ...extras,
+        ...(opts.args ? { args: opts.args } : {}),
+      },
+      api,
+      dispose
+    );
   }
 
   #compilerCache = new WeakMap();
@@ -595,28 +692,42 @@ export class Compiler {
    * @param {import('./types.ts').Compiler} compiler
    * @param {string} whatToRender
    * @param {{ compiled: string } & Record<string, unknown>} extras
+   * @param {import('./types.ts').CompileAPI} api
+   * @param {() => void} dispose
    * @returns {Promise<{ element: HTMLElement, destroy: () => void }>}
    */
-  async #render(compiler, whatToRender, extras) {
+  async #render(compiler, whatToRender, extras, api, dispose) {
     this.#announce('info', 'Rendering');
 
     const div = this.#createDiv();
 
-    assert(`Cannot render falsey values. Did compilation succeed?`, whatToRender);
+    try {
+      assert(`Cannot render falsey values. Did compilation succeed?`, whatToRender);
 
-    const destroy = await compiler.render(div, whatToRender, extras, this.#nestedPublicAPI);
+      const destroy = await compiler.render(div, whatToRender, extras, api);
 
-    // Wait for render
-    await new Promise((resolve) => requestAnimationFrame(resolve));
+      // Wait for render
+      await new Promise((resolve) => requestAnimationFrame(resolve));
 
-    return {
-      element: div,
-      destroy: () => {
-        if (destroy) {
-          return destroy();
-        }
-      },
-    };
+      return {
+        element: div,
+        // The caller's `destroy` releases everything this compile pinned —
+        // first the compiler's own teardown (DOM detach, framework
+        // destructors, …), then any scopes the compiler exposed via
+        // `api.provideScope`. Individual compilers don't (and shouldn't)
+        // know about the scope lifecycle; the Compiler owns it.
+        destroy: () => {
+          try {
+            if (destroy) destroy();
+          } finally {
+            dispose();
+          }
+        },
+      };
+    } catch (e) {
+      dispose();
+      throw e;
+    }
   }
 
   /**
@@ -763,38 +874,6 @@ export class Compiler {
      */
     compileToSource: (...args) => this.compileToSource(...args),
 
-    /**
-     * Register a JS value to be resolvable as an ES module under a virtual
-     * import specifier. Returns a cleanup function that unregisters it.
-     *
-     * Compilers use this when their emitted source needs to reach back to a
-     * runtime value that can't be serialized into a module string —
-     * typically a live scope object. The emitted source can then
-     * `import * as scope from '${specifier}'` and rely on the compiler's
-     * resolver to fetch the value, instead of every compiler hand-rolling
-     * its own `globalThis` namespace.
-     *
-     * Under the hood this layers on the same `manual:` resolver +
-     * `cache.resolves` machinery the Compiler already uses for caller-
-     * supplied `options.resolve` entries.
-     *
-     * @param {string} specifier
-     * @param {unknown} value
-     * @returns {() => void}
-     */
-    provide: (specifier, value) => {
-      this.#options.resolve ??= {};
-      this.#options.resolve[specifier] = value;
-      cache.resolves[specifier] = value;
-
-      return () => {
-        if (this.#options.resolve) {
-          delete this.#options.resolve[specifier];
-        }
-
-        delete cache.resolves[specifier];
-      };
-    },
     /**
      * @param {Parameters<Compiler['optionsFor']>} args
      */

--- a/packages/repl-sdk/src/index.js
+++ b/packages/repl-sdk/src/index.js
@@ -762,6 +762,39 @@ export class Compiler {
      * @param {Parameters<Compiler['compileToSource']>} args
      */
     compileToSource: (...args) => this.compileToSource(...args),
+
+    /**
+     * Register a JS value to be resolvable as an ES module under a virtual
+     * import specifier. Returns a cleanup function that unregisters it.
+     *
+     * Compilers use this when their emitted source needs to reach back to a
+     * runtime value that can't be serialized into a module string —
+     * typically a live scope object. The emitted source can then
+     * `import * as scope from '${specifier}'` and rely on the compiler's
+     * resolver to fetch the value, instead of every compiler hand-rolling
+     * its own `globalThis` namespace.
+     *
+     * Under the hood this layers on the same `manual:` resolver +
+     * `cache.resolves` machinery the Compiler already uses for caller-
+     * supplied `options.resolve` entries.
+     *
+     * @param {string} specifier
+     * @param {unknown} value
+     * @returns {() => void}
+     */
+    provide: (specifier, value) => {
+      this.#options.resolve ??= {};
+      this.#options.resolve[specifier] = value;
+      cache.resolves[specifier] = value;
+
+      return () => {
+        if (this.#options.resolve) {
+          delete this.#options.resolve[specifier];
+        }
+
+        delete cache.resolves[specifier];
+      };
+    },
     /**
      * @param {Parameters<Compiler['optionsFor']>} args
      */

--- a/packages/repl-sdk/src/index.js
+++ b/packages/repl-sdk/src/index.js
@@ -22,18 +22,6 @@ export const defaults = {
   formats: compilers,
 };
 
-/**
- * Namespaces the virtual specifiers `api.provideScope` hands back.
- *
- * Module-scoped, not per-Compiler: the es-module-shim's registry is global to
- * the page and caches each specifier's exports the first time it is fetched.
- * A per-instance counter restarts at 1 for every new Compiler, so a second
- * Compiler would hand out a specifier whose module was already cached against
- * an earlier compile's scope keys, and every key added since would resolve to
- * undefined.
- */
-let scopeCounter = 0;
-
 export class Compiler {
   /** @type {Options} */
   #options;
@@ -49,54 +37,6 @@ export class Compiler {
     STABLE_REFERENCE.fetch = this.#fetch;
 
     window.addEventListener('unhandledrejection', this.#handleUnhandledRejection);
-  }
-
-  /**
-   * Build a per-compile API: the same shape as the shared `PublicMethods`
-   * but with an extra `provideScope(value)` method whose registrations are
-   * tracked by `registry`. After the compile (and any render it triggers)
-   * finishes, the Compiler calls `dispose()` to release everything in
-   * `registry` — so individual compilers never have to remember to clean
-   * up the values they expose through `provideScope`.
-   *
-   * @returns {{
-   *   api: import('./types.ts').CompileAPI,
-   *   dispose: () => void,
-   * }}
-   */
-  #createCompileScope() {
-    /** @type {Set<string>} */
-    const registry = new Set();
-
-    const provideScope = (/** @type {unknown} */ value) => {
-      const specifier = `repl-sdk:scope:${++scopeCounter}`;
-
-      this.#options.resolve ??= {};
-      this.#options.resolve[specifier] = value;
-      cache.resolves[specifier] = value;
-      registry.add(specifier);
-
-      return { specifier };
-    };
-
-    const dispose = () => {
-      for (const specifier of registry) {
-        if (this.#options.resolve) {
-          delete this.#options.resolve[specifier];
-        }
-
-        delete cache.resolves[specifier];
-      }
-
-      registry.clear();
-    };
-
-    const api = /** @type {import('./types.ts').CompileAPI} */ ({
-      ...this.#nestedPublicAPI,
-      provideScope,
-    });
-
-    return { api, dispose };
   }
 
   /**
@@ -483,44 +423,30 @@ export class Compiler {
     const opts = { ...options, fileName, renderToString: true };
 
     const compiler = await this.#getCompiler(format, flavor);
-    const { api, dispose } = this.#createCompileScope();
+    const compiled = await compiler.compile(text, opts);
 
-    try {
-      const compiled = await compiler.compile(text, opts, api);
-
-      if (typeof compiled === 'string') {
-        return { source: compiled };
-      }
-
-      if (
-        compiled !== null &&
-        typeof compiled === 'object' &&
-        'source' in compiled &&
-        typeof compiled.source === 'string'
-      ) {
-        return { source: compiled.source };
-      }
-
-      const shape =
-        compiled !== null && typeof compiled === 'object'
-          ? Object.keys(compiled).join(', ')
-          : typeof compiled;
-
-      throw new Error(
-        `Compiler for format '${format}' was asked to renderToString but returned ` +
-          `${shape} instead of a source string.`
-      );
-    } finally {
-      // renderToString never renders, so anything `provideScope` registered
-      // during this compile has no rendered-element lifecycle to attach to.
-      // Release it immediately — the emitted source string was constructed
-      // with the scope inlined as a virtual specifier reference, but the
-      // *value* behind that specifier is only meaningful while this compile
-      // is in flight (e.g. for gmd's nested renderToString sub-compiles to
-      // share helpers with their parent). The caller's bundler resolves the
-      // specifier statically at build time; runtime lookup is never used.
-      dispose();
+    if (typeof compiled === 'string') {
+      return { source: compiled };
     }
+
+    if (
+      compiled !== null &&
+      typeof compiled === 'object' &&
+      'source' in compiled &&
+      typeof compiled.source === 'string'
+    ) {
+      return { source: compiled.source };
+    }
+
+    const shape =
+      compiled !== null && typeof compiled === 'object'
+        ? Object.keys(compiled).join(', ')
+        : typeof compiled;
+
+    throw new Error(
+      `Compiler for format '${format}' was asked to renderToString but returned ` +
+        `${shape} instead of a source string.`
+    );
   }
 
   /**
@@ -542,16 +468,7 @@ export class Compiler {
     this.#log('[compile] compiling');
 
     const compiler = await this.#getCompiler(format, opts.flavor);
-    const { api, dispose } = this.#createCompileScope();
-
-    let compiled;
-
-    try {
-      compiled = await compiler.compile(text, opts, api);
-    } catch (e) {
-      dispose();
-      throw e;
-    }
+    const compiled = await compiler.compile(text, opts);
 
     let compiledText = 'export default "failed to compile"';
     let extras = { compiled: '' };
@@ -575,43 +492,24 @@ export class Compiler {
         extras = compiled;
       }
 
-      return this.#render(
-        compiler,
-        value,
-        {
-          ...extras,
-          compiled: value,
-          ...(opts.args ? { args: opts.args } : {}),
-        },
-        api,
-        dispose
-      );
+      return this.#render(compiler, value, {
+        ...extras,
+        compiled: value,
+        ...(opts.args ? { args: opts.args } : {}),
+      });
     }
 
-    let defaultExport;
+    const asBlobUrl = textToBlobUrl(compiledText);
 
-    try {
-      const asBlobUrl = textToBlobUrl(compiledText);
-
-      // @ts-ignore
-      ({ default: defaultExport } = await shimmedImport(/* @vite-ignore */ asBlobUrl));
-    } catch (e) {
-      dispose();
-      throw e;
-    }
+    // @ts-ignore
+    const { default: defaultExport } = await shimmedImport(/* @vite-ignore */ asBlobUrl);
 
     this.#log('[compile] preparing to render', defaultExport, extras);
 
-    return this.#render(
-      compiler,
-      defaultExport,
-      {
-        ...extras,
-        ...(opts.args ? { args: opts.args } : {}),
-      },
-      api,
-      dispose
-    );
+    return this.#render(compiler, defaultExport, {
+      ...extras,
+      ...(opts.args ? { args: opts.args } : {}),
+    });
   }
 
   #compilerCache = new WeakMap();
@@ -697,42 +595,28 @@ export class Compiler {
    * @param {import('./types.ts').Compiler} compiler
    * @param {string} whatToRender
    * @param {{ compiled: string } & Record<string, unknown>} extras
-   * @param {import('./types.ts').CompileAPI} api
-   * @param {() => void} dispose
    * @returns {Promise<{ element: HTMLElement, destroy: () => void }>}
    */
-  async #render(compiler, whatToRender, extras, api, dispose) {
+  async #render(compiler, whatToRender, extras) {
     this.#announce('info', 'Rendering');
 
     const div = this.#createDiv();
 
-    try {
-      assert(`Cannot render falsey values. Did compilation succeed?`, whatToRender);
+    assert(`Cannot render falsey values. Did compilation succeed?`, whatToRender);
 
-      const destroy = await compiler.render(div, whatToRender, extras, api);
+    const destroy = await compiler.render(div, whatToRender, extras, this.#nestedPublicAPI);
 
-      // Wait for render
-      await new Promise((resolve) => requestAnimationFrame(resolve));
+    // Wait for render
+    await new Promise((resolve) => requestAnimationFrame(resolve));
 
-      return {
-        element: div,
-        // The caller's `destroy` releases everything this compile pinned —
-        // first the compiler's own teardown (DOM detach, framework
-        // destructors, …), then any scopes the compiler exposed via
-        // `api.provideScope`. Individual compilers don't (and shouldn't)
-        // know about the scope lifecycle; the Compiler owns it.
-        destroy: () => {
-          try {
-            if (destroy) destroy();
-          } finally {
-            dispose();
-          }
-        },
-      };
-    } catch (e) {
-      dispose();
-      throw e;
-    }
+    return {
+      element: div,
+      destroy: () => {
+        if (destroy) {
+          return destroy();
+        }
+      },
+    };
   }
 
   /**

--- a/packages/repl-sdk/src/index.js
+++ b/packages/repl-sdk/src/index.js
@@ -347,18 +347,47 @@ export class Compiler {
   /**
    * @param {string} format
    * @param {string} text
-   * @param {{ fileName?: string, flavor?: string, args?: Record<string, unknown>, renderToString?: boolean, [key: string]: unknown }} [ options ]
-   * @returns {Promise<{ element: HTMLElement, destroy: () => void } | { source: string }>}
+   * @param {{ fileName?: string, flavor?: string, args?: Record<string, unknown>, [key: string]: unknown }} [ options ]
+   * @returns {Promise<{ element: HTMLElement, destroy: () => void }>}
    */
   async compile(format, text, options = {}) {
+    return this.#runCompile(this.#compile, format, text, options);
+  }
+
+  /**
+   * Build-time variant of {@link Compiler.compile}: returns the compiled JS
+   * module source as a string instead of evaluating and rendering. Each
+   * configured compiler sees `renderToString: true` on its options and is
+   * expected to emit a source string (`string` or `{ source: string, … }`)
+   * rather than a runtime component.
+   *
+   * @param {string} format
+   * @param {string} text
+   * @param {Record<string, unknown>} [options]
+   * @returns {Promise<{ source: string }>}
+   */
+  async compileToSource(format, text, options = {}) {
+    return this.#runCompile(this.#compileToSource, format, text, options);
+  }
+
+  /**
+   * Shared wrapper for `compile` / `compileToSource`: announces lifecycle
+   * messages and forwards any thrown error through `on.log` before letting
+   * it propagate. Both public entry points share this so the user-visible
+   * logging is identical whether they're rendering or just getting source.
+   *
+   * @template T
+   * @param {(format: string, text: string, options: Record<string, unknown>) => Promise<T>} impl
+   * @param {string} format
+   * @param {string} text
+   * @param {Record<string, unknown>} options
+   * @returns {Promise<T>}
+   */
+  async #runCompile(impl, format, text, options) {
     this.#announce('info', `Compiling ${format}`);
 
     try {
-      if (options.renderToString) {
-        return await this.#compileToSource(format, text, options);
-      }
-
-      return await this.#compile(format, text, options);
+      return await impl.call(this, format, text, options);
     } catch (e) {
       // for on.log usage
       this.#announce('error', errorMessage(e));
@@ -367,22 +396,6 @@ export class Compiler {
       this.#error(e);
       throw e;
     }
-  }
-
-  /**
-   * Build-time variant of {@link Compiler.compile}: returns the compiled JS
-   * module source as a string instead of evaluating and rendering. Equivalent
-   * to `compile(format, text, { ...options, renderToString: true })`.
-   *
-   * @param {string} format
-   * @param {string} text
-   * @param {Record<string, unknown>} [options]
-   * @returns {Promise<{ source: string }>}
-   */
-  async compileToSource(format, text, options = {}) {
-    return /** @type {{ source: string }} */ (
-      await this.compile(format, text, { ...options, renderToString: true })
-    );
   }
 
   /**
@@ -405,29 +418,34 @@ export class Compiler {
    * @returns {Promise<{ source: string }>}
    */
   async #compileToSource(format, text, options) {
-    /** @type {Record<string, unknown>} */
-    const opts = { ...options, renderToString: true };
+    const flavor = typeof options.flavor === 'string' ? options.flavor : undefined;
+    const fileName = typeof options.fileName === 'string' ? options.fileName : `dynamic.${format}`;
+    const opts = { ...options, fileName, renderToString: true };
 
-    opts.fileName ||= `dynamic.${format}`;
-
-    const compiler = await this.#getCompiler(
-      format,
-      /** @type {string | undefined} */ (opts.flavor)
-    );
+    const compiler = await this.#getCompiler(format, flavor);
     const compiled = await compiler.compile(text, opts);
 
     if (typeof compiled === 'string') {
       return { source: compiled };
     }
 
-    if (compiled && typeof (/** @type {{source?: unknown}} */ (compiled).source) === 'string') {
-      return /** @type {{source: string}} */ (compiled);
+    if (
+      compiled !== null &&
+      typeof compiled === 'object' &&
+      'source' in compiled &&
+      typeof compiled.source === 'string'
+    ) {
+      return { source: compiled.source };
     }
+
+    const shape =
+      compiled !== null && typeof compiled === 'object'
+        ? Object.keys(compiled).join(', ')
+        : typeof compiled;
 
     throw new Error(
       `Compiler for format '${format}' was asked to renderToString but returned ` +
-        `${typeof compiled === 'object' ? Object.keys(/** @type {object} */ (compiled)).join(', ') : typeof compiled} ` +
-        `instead of a source string.`
+        `${shape} instead of a source string.`
     );
   }
 

--- a/packages/repl-sdk/src/render-to-string.js
+++ b/packages/repl-sdk/src/render-to-string.js
@@ -225,28 +225,26 @@ function indent(text) {
  *     evaluated at runtime, or `'@ember/template-compiler'` when a build-
  *     time babel plugin is expected to precompile the `template(...)` call.
  *
- *   - `scope`: a string expression (e.g.
- *     `globalThis[Symbol.for('repl-sdk:gmd-scope:42')]`) that, at module
- *     evaluation time, returns the live runtime scope object. The keys
- *     listed in `scopeKeys` are destructured from that expression and
- *     spread into the prose template's `scope: () => ({...})` call,
- *     letting helpers like `array`, `concat`, etc. cross the source
- *     boundary without needing dedicated imports. Pass `null` (the default)
- *     to skip scope-via-global entirely — used for renderToString, where
- *     there is no live scope.
+ *   - `scope`: a virtual ES module specifier that the emitted module will
+ *     `import * as __scope__ from '<specifier>'`, and the list of keys to
+ *     destructure off that namespace. The runtime path registers the live
+ *     scope object behind such a specifier via `api.provide`; the
+ *     renderToString path passes `null` because there is no live scope to
+ *     bridge.
  *
  * The placeholders in `prose` are replaced with `<name />` Glimmer
  * invocations wrapped in a div that preserves the original placeholder's
  * `class` attribute (e.g. `repl-sdk__demo`) so existing CSS still applies.
  *
  * This is a pure function — the caller is responsible for driving the
- * sub-compiles and stashing the scope object if it uses `scope`/`scopeKeys`.
+ * sub-compiles and (for the runtime path) for registering the scope value
+ * behind `scope.specifier` before this output is evaluated.
  *
  * @param {object} args
  * @param {string} args.prose
  * @param {Array<{ name: string, placeholderId: string, source: string }>} args.demos
  * @param {string} [args.templateModule]
- * @param {{ expression: string, keys: string[] } | null} [args.scope]
+ * @param {{ specifier: string, keys: string[] } | null} [args.scope]
  * @returns {string}
  */
 export function buildGmdModule({
@@ -257,6 +255,11 @@ export function buildGmdModule({
 }) {
   /** @type {string[][]} */
   const importGroups = [[`import { template } from '${templateModule}';`]];
+
+  if (scope && scope.keys.length) {
+    importGroups.push([`import * as __scope__ from '${scope.specifier}';`]);
+  }
+
   /** @type {string[]} */
   const bodyDecls = [];
   /** @type {string[]} */
@@ -280,7 +283,6 @@ export function buildGmdModule({
   const preludeLines = [];
 
   if (scope && scope.keys.length) {
-    preludeLines.push(`const __scope__ = ${scope.expression};`);
     preludeLines.push(`const { ${scope.keys.join(', ')} } = __scope__;`);
   }
 

--- a/packages/repl-sdk/src/render-to-string.js
+++ b/packages/repl-sdk/src/render-to-string.js
@@ -213,31 +213,50 @@ function indent(text) {
 }
 
 /**
- * Inline one or more compiled sub-modules into the surrounding gmd prose.
+ * Inline one or more compiled sub-modules into the surrounding gmd prose,
+ * producing one self-contained ES module string.
  *
- * Given the markdown body (with `<div id="placeholderId"></div>` holes from
- * `liveCodeExtraction`) and a list of `{ name, placeholderId, source }`
- * entries (one per live demo), produce a single `.gjs`-shaped module:
+ * The same function is used by both the *runtime* compile path (the module
+ * gets blob-eval'd and rendered) and the *renderToString* path (the module
+ * gets handed back to the caller's bundler). The only differences are:
  *
- *   - All top-level demo imports merged + deduped at the top
- *   - Plus `import { template } from '@ember/template-compiler';`
- *   - Each demo body wrapped in `const <name> = (() => { …; return X; })();`
- *   - A trailing `template(prose, { scope: () => ({ …names… }) })` call
+ *   - `templateModule`: which `template` to import. Use
+ *     `'@ember/template-compiler/runtime'` when this module will be
+ *     evaluated at runtime, or `'@ember/template-compiler'` when a build-
+ *     time babel plugin is expected to precompile the `template(...)` call.
+ *
+ *   - `scope`: a string expression (e.g.
+ *     `globalThis[Symbol.for('repl-sdk:gmd-scope:42')]`) that, at module
+ *     evaluation time, returns the live runtime scope object. The keys
+ *     listed in `scopeKeys` are destructured from that expression and
+ *     spread into the prose template's `scope: () => ({...})` call,
+ *     letting helpers like `array`, `concat`, etc. cross the source
+ *     boundary without needing dedicated imports. Pass `null` (the default)
+ *     to skip scope-via-global entirely — used for renderToString, where
+ *     there is no live scope.
  *
  * The placeholders in `prose` are replaced with `<name />` Glimmer
- * invocations referencing each inlined demo.
+ * invocations wrapped in a div that preserves the original placeholder's
+ * `class` attribute (e.g. `repl-sdk__demo`) so existing CSS still applies.
  *
- * This is a pure function — the caller (e.g. `gmd.js`) is responsible for
- * driving the sub-compiles.
+ * This is a pure function — the caller is responsible for driving the
+ * sub-compiles and stashing the scope object if it uses `scope`/`scopeKeys`.
  *
  * @param {object} args
  * @param {string} args.prose
  * @param {Array<{ name: string, placeholderId: string, source: string }>} args.demos
+ * @param {string} [args.templateModule]
+ * @param {{ expression: string, keys: string[] } | null} [args.scope]
  * @returns {string}
  */
-export function buildGmdModule({ prose, demos }) {
+export function buildGmdModule({
+  prose,
+  demos,
+  templateModule = '@ember/template-compiler',
+  scope = null,
+}) {
   /** @type {string[][]} */
-  const importGroups = [[`import { template } from '@ember/template-compiler';`]];
+  const importGroups = [[`import { template } from '${templateModule}';`]];
   /** @type {string[]} */
   const bodyDecls = [];
   /** @type {string[]} */
@@ -256,10 +275,21 @@ export function buildGmdModule({ prose, demos }) {
   }
 
   const mergedImports = mergeImports(importGroups).join('\n');
-  const scopeBody = scopeIdents.length ? `{ ${scopeIdents.join(', ')} }` : `{}`;
+
+  /** @type {string[]} */
+  const preludeLines = [];
+
+  if (scope && scope.keys.length) {
+    preludeLines.push(`const __scope__ = ${scope.expression};`);
+    preludeLines.push(`const { ${scope.keys.join(', ')} } = __scope__;`);
+  }
+
+  const allScopeIdents = scope && scope.keys.length ? [...scope.keys, ...scopeIdents] : scopeIdents;
+  const scopeBody = allScopeIdents.length ? `{ ${allScopeIdents.join(', ')} }` : `{}`;
 
   return (
     `${mergedImports}\n\n` +
+    (preludeLines.length ? preludeLines.join('\n') + '\n\n' : '') +
     (bodyDecls.length ? bodyDecls.join('\n\n') + '\n\n' : '') +
     `const _component = template(${JSON.stringify(rewrittenProse)}, {\n` +
     `  scope: () => (${scopeBody}),\n` +
@@ -269,19 +299,25 @@ export function buildGmdModule({ prose, demos }) {
 }
 
 /**
- * Replace the single `<div id="${id}" …></div>` placeholder emitted by
- * `liveCodeExtraction` with a Glimmer component invocation `<${name} />`.
- *
- * The placeholder element has no inner text and may carry arbitrary class
- * attributes; we only need to match it by id.
+ * Replace the single `<div id="${id}" class="…"></div>` placeholder emitted
+ * by `liveCodeExtraction` with a Glimmer component invocation. The wrapping
+ * div is preserved (sans `id`) so the `repl-sdk__demo` (or
+ * caller-supplied) class still styles the demo container.
  *
  * @param {string} html
  * @param {string} id
  * @param {string} name
  */
 export function replacePlaceholder(html, id, name) {
-  const escaped = id.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
-  const pattern = new RegExp(`<div\\s+id="${escaped}"[^>]*>\\s*</div>`, 'g');
+  const escapedId = id.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+  const pattern = new RegExp(
+    `<div\\s+id="${escapedId}"(\\s+class="([^"]*)")?[^>]*>\\s*</div>`,
+    'g'
+  );
 
-  return html.replace(pattern, `<${name} />`);
+  return html.replace(pattern, (_match, _attr, classes) => {
+    const classAttr = classes !== undefined ? ` class="${classes}"` : '';
+
+    return `<div${classAttr}><${name} /></div>`;
+  });
 }

--- a/packages/repl-sdk/src/render-to-string.js
+++ b/packages/repl-sdk/src/render-to-string.js
@@ -1,0 +1,287 @@
+/**
+ * Shared helpers for the build-time `renderToString` code path.
+ *
+ * The job of these helpers is purely lexical — given the JS source emitted by
+ * a sub-compiler (e.g. gjs/hbs), split it into top-level imports + body so
+ * the caller (e.g. `gmd`) can merge many such modules into one self-contained
+ * module string that the host app's own bundler will then process.
+ *
+ * Nothing here parses JS into an AST — the input is expected to be the
+ * deterministic output of babel + content-tag, where imports are top-level
+ * and the module ends with a single `export default <expr>;`.
+ */
+
+/**
+ * @typedef {object} ModuleParts
+ * @property {string[]} imports - Top-level import statements (each ending in `;`)
+ * @property {string} body - Remaining module body with imports removed and
+ *   `export default <expr>;` rewritten to `return <expr>;`
+ */
+
+/**
+ * Split a JS module source into its top-level import statements and the rest
+ * of its body, rewriting any trailing `export default <expr>;` to a `return`
+ * so the body is suitable for IIFE-wrapping.
+ *
+ * Multi-line imports (`import {\n  a,\n  b\n} from 'x';`) are supported by
+ * brace-balanced continuation across lines.
+ *
+ * @param {string} source
+ * @returns {ModuleParts}
+ */
+export function splitModule(source) {
+  const lines = source.split('\n');
+  /** @type {string[]} */
+  const imports = [];
+  /** @type {string[]} */
+  const bodyLines = [];
+
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = /** @type {string} */ (lines[i]);
+
+    if (!isImportStart(line)) {
+      bodyLines.push(line);
+      i++;
+      continue;
+    }
+
+    let chunk = line;
+    let depth = braceDelta(line);
+    let parenDepth = parenDelta(line);
+
+    while (
+      i + 1 < lines.length &&
+      (depth > 0 || parenDepth > 0 || !chunk.trimEnd().endsWith(';'))
+    ) {
+      i++;
+
+      const next = /** @type {string} */ (lines[i]);
+
+      chunk += '\n' + next;
+      depth += braceDelta(next);
+      parenDepth += parenDelta(next);
+    }
+
+    imports.push(chunk);
+    i++;
+  }
+
+  const body = rewriteDefaultExport(bodyLines.join('\n'));
+
+  return { imports, body };
+}
+
+/**
+ * @param {string} line
+ */
+function isImportStart(line) {
+  return /^\s*import(\s|\s*['"`{*])/.test(line);
+}
+
+/**
+ * Count `{` − `}` in a line, ignoring chars inside strings or line comments.
+ * Good enough for the small set of characters babel emits inside an import
+ * statement (no template literals, no regex literals).
+ *
+ * @param {string} line
+ */
+function braceDelta(line) {
+  return countCharsOutsideStrings(line, '{', '}');
+}
+
+/**
+ * @param {string} line
+ */
+function parenDelta(line) {
+  return countCharsOutsideStrings(line, '(', ')');
+}
+
+/**
+ * @param {string} line
+ * @param {string} open
+ * @param {string} close
+ */
+function countCharsOutsideStrings(line, open, close) {
+  let depth = 0;
+  /** @type {string | null} */
+  let stringChar = null;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+
+    if (stringChar) {
+      if (ch === '\\') {
+        i++;
+        continue;
+      }
+
+      if (ch === stringChar) {
+        stringChar = null;
+      }
+
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === '`') {
+      stringChar = ch;
+      continue;
+    }
+
+    if (ch === '/' && line[i + 1] === '/') break;
+
+    if (ch === open) depth++;
+    else if (ch === close) depth--;
+  }
+
+  return depth;
+}
+
+/**
+ * Rewrite the final `export default <expr>;` to `return <expr>;` so the
+ * caller can wrap the body in an IIFE.
+ *
+ * If there is no `export default`, the body is returned unchanged.
+ *
+ * @param {string} body
+ * @returns {string}
+ */
+function rewriteDefaultExport(body) {
+  // Anchor with `/m` so we only match `export default` at the start of a
+  // statement line — never inside line comments, strings, or expressions.
+  // Babel never emits multiple top-level `export default`s, so first-match
+  // semantics are fine.
+  const match = body.match(/^\s*export\s+default\s+/m);
+
+  if (!match || match.index === undefined) {
+    return body;
+  }
+
+  const before = body.slice(0, match.index);
+  const after = body.slice(match.index + match[0].length);
+
+  return `${before}return ${after}`;
+}
+
+/**
+ * Deduplicate a list of import statements by their exact textual content
+ * (after trimming trailing whitespace). This is intentionally conservative —
+ * we'd rather emit two equivalent-but-different imports than collapse two
+ * imports that bind different things.
+ *
+ * @param {string[][]} groups
+ * @returns {string[]}
+ */
+export function mergeImports(groups) {
+  const seen = new Set();
+  /** @type {string[]} */
+  const out = [];
+
+  for (const group of groups) {
+    for (const imp of group) {
+      const key = imp.trim();
+
+      if (seen.has(key)) continue;
+
+      seen.add(key);
+      out.push(imp);
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Wrap a module body in an IIFE that returns the (rewritten) default export.
+ *
+ * @param {string} body
+ * @param {string} name
+ */
+export function wrapAsConst(body, name) {
+  return `const ${name} = (() => {\n${indent(body)}\n})();`;
+}
+
+/**
+ * @param {string} text
+ */
+function indent(text) {
+  return text
+    .split('\n')
+    .map((line) => (line.length ? `  ${line}` : line))
+    .join('\n');
+}
+
+/**
+ * Inline one or more compiled sub-modules into the surrounding gmd prose.
+ *
+ * Given the markdown body (with `<div id="placeholderId"></div>` holes from
+ * `liveCodeExtraction`) and a list of `{ name, placeholderId, source }`
+ * entries (one per live demo), produce a single `.gjs`-shaped module:
+ *
+ *   - All top-level demo imports merged + deduped at the top
+ *   - Plus `import { template } from '@ember/template-compiler';`
+ *   - Each demo body wrapped in `const <name> = (() => { …; return X; })();`
+ *   - A trailing `template(prose, { scope: () => ({ …names… }) })` call
+ *
+ * The placeholders in `prose` are replaced with `<name />` Glimmer
+ * invocations referencing each inlined demo.
+ *
+ * This is a pure function — the caller (e.g. `gmd.js`) is responsible for
+ * driving the sub-compiles.
+ *
+ * @param {object} args
+ * @param {string} args.prose
+ * @param {Array<{ name: string, placeholderId: string, source: string }>} args.demos
+ * @returns {string}
+ */
+export function buildGmdModule({ prose, demos }) {
+  /** @type {string[][]} */
+  const importGroups = [[`import { template } from '@ember/template-compiler';`]];
+  /** @type {string[]} */
+  const bodyDecls = [];
+  /** @type {string[]} */
+  const scopeIdents = [];
+
+  let rewrittenProse = prose;
+
+  for (const demo of demos) {
+    const { imports, body } = splitModule(demo.source);
+
+    importGroups.push(imports);
+    bodyDecls.push(wrapAsConst(body, demo.name));
+    scopeIdents.push(demo.name);
+
+    rewrittenProse = replacePlaceholder(rewrittenProse, demo.placeholderId, demo.name);
+  }
+
+  const mergedImports = mergeImports(importGroups).join('\n');
+  const scopeBody = scopeIdents.length ? `{ ${scopeIdents.join(', ')} }` : `{}`;
+
+  return (
+    `${mergedImports}\n\n` +
+    (bodyDecls.length ? bodyDecls.join('\n\n') + '\n\n' : '') +
+    `const _component = template(${JSON.stringify(rewrittenProse)}, {\n` +
+    `  scope: () => (${scopeBody}),\n` +
+    `});\n` +
+    `export default _component;\n`
+  );
+}
+
+/**
+ * Replace the single `<div id="${id}" …></div>` placeholder emitted by
+ * `liveCodeExtraction` with a Glimmer component invocation `<${name} />`.
+ *
+ * The placeholder element has no inner text and may carry arbitrary class
+ * attributes; we only need to match it by id.
+ *
+ * @param {string} html
+ * @param {string} id
+ * @param {string} name
+ */
+export function replacePlaceholder(html, id, name) {
+  const escaped = id.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+  const pattern = new RegExp(`<div\\s+id="${escaped}"[^>]*>\\s*</div>`, 'g');
+
+  return html.replace(pattern, `<${name} />`);
+}

--- a/packages/repl-sdk/src/render-to-string.js
+++ b/packages/repl-sdk/src/render-to-string.js
@@ -31,17 +31,26 @@
  */
 export function splitModule(source) {
   const lines = source.split('\n');
+  const topLevel = topLevelMask(source);
   /** @type {string[]} */
   const imports = [];
   /** @type {string[]} */
   const bodyLines = [];
 
   let i = 0;
+  let offset = 0;
 
   while (i < lines.length) {
     const line = /** @type {string} */ (lines[i]);
+    const lineStart = offset;
 
-    if (!isImportStart(line)) {
+    offset += line.length + 1;
+
+    // A demo that quotes Ember code (the "build your own REPL" sample assigns
+    // a whole component to a template literal) has `import …` at column 0
+    // inside that literal. Hoisting those lines out silently strips the
+    // quoted module's own imports, so gate on real top-level position.
+    if (!isImportStart(line) || !isTopLevelAt(topLevel, lineStart + indentOf(line))) {
       bodyLines.push(line);
       i++;
       continue;
@@ -59,6 +68,7 @@ export function splitModule(source) {
 
       const next = /** @type {string} */ (lines[i]);
 
+      offset += next.length + 1;
       chunk += '\n' + next;
       depth += braceDelta(next);
       parenDepth += parenDelta(next);
@@ -148,20 +158,177 @@ function countCharsOutsideStrings(line, open, close) {
  * @returns {string}
  */
 function rewriteDefaultExport(body) {
-  // Anchor with `/m` so we only match `export default` at the start of a
-  // statement line — never inside line comments, strings, or expressions.
-  // Babel never emits multiple top-level `export default`s, so first-match
-  // semantics are fine.
-  const match = body.match(/^\s*export\s+default\s+/m);
+  const found = findTopLevelExportDefault(body);
 
-  if (!match || match.index === undefined) {
+  if (!found) {
     return body;
   }
 
-  const before = body.slice(0, match.index);
-  const after = body.slice(match.index + match[0].length);
+  const before = body.slice(0, found.index);
+  const after = body.slice(found.index + found.length);
 
   return `${before}return ${after}`;
+}
+
+/**
+ * Locate the module's own `export default`, skipping any that appear inside
+ * strings, template literals, or comments.
+ *
+ * A line-anchored regex is not enough: a demo that shows Ember code as a
+ * string (the "build your own REPL" sample assigns a whole component to a
+ * template literal) has `export default` at column 0 *inside* that literal.
+ * Rewriting there corrupts the string and leaves the real export in place,
+ * so the IIFE wrapper dies with "Unexpected token 'export'".
+ *
+ * @param {string} body
+ * @returns {{ index: number, length: number } | null}
+ */
+function findTopLevelExportDefault(body) {
+  const topLevel = topLevelMask(body);
+  const pattern = /export\s+default\s+/g;
+
+  /** @type {RegExpExecArray | null} */
+  let match;
+
+  while ((match = pattern.exec(body)) !== null) {
+    if (isTopLevelAt(topLevel, match.index) && !isWordChar(body[match.index - 1])) {
+      return { index: match.index, length: match[0].length };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Mark every offset in `source` that sits in top-level module code — outside
+ * any string, template literal, or comment, and at brace depth zero.
+ *
+ * Everything that rewrites a module by position depends on this: both the
+ * import hoist and the `export default` rewrite would otherwise fire on text
+ * that merely looks like code because a demo quoted it.
+ *
+ * @param {string} source
+ * @returns {Uint8Array}
+ */
+function topLevelMask(source) {
+  const mask = new Uint8Array(source.length);
+  /** @type {Array<{ type: 'code' | 'sq' | 'dq' | 'tpl', depth: number }>} */
+  const stack = [{ type: 'code', depth: 0 }];
+  let i = 0;
+
+  while (i < source.length) {
+    const top = /** @type {{ type: string, depth: number }} */ (stack[stack.length - 1]);
+    const ch = source[i];
+
+    if (top.type === 'sq' || top.type === 'dq') {
+      if (ch === '\\') {
+        i += 2;
+        continue;
+      }
+
+      if ((top.type === 'sq' && ch === "'") || (top.type === 'dq' && ch === '"')) {
+        stack.pop();
+      }
+
+      i++;
+      continue;
+    }
+
+    if (top.type === 'tpl') {
+      if (ch === '\\') {
+        i += 2;
+        continue;
+      }
+
+      if (ch === '`') {
+        stack.pop();
+        i++;
+        continue;
+      }
+
+      // `${` opens a nested code context that can itself contain strings
+      if (ch === '$' && source[i + 1] === '{') {
+        stack.push({ type: 'code', depth: 0 });
+        i += 2;
+        continue;
+      }
+
+      i++;
+      continue;
+    }
+
+    if (ch === '/' && source[i + 1] === '/') {
+      const newline = source.indexOf('\n', i);
+
+      i = newline === -1 ? source.length : newline;
+      continue;
+    }
+
+    if (ch === '/' && source[i + 1] === '*') {
+      const end = source.indexOf('*/', i + 2);
+
+      i = end === -1 ? source.length : end + 2;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"' || ch === '`') {
+      stack.push({ type: ch === "'" ? 'sq' : ch === '"' ? 'dq' : 'tpl', depth: 0 });
+      i++;
+      continue;
+    }
+
+    if (ch === '{') {
+      top.depth++;
+      i++;
+      continue;
+    }
+
+    if (ch === '}') {
+      // depth 0 inside a nested context means this `}` closes a `${`
+      if (top.depth === 0 && stack.length > 1) {
+        stack.pop();
+      } else {
+        top.depth--;
+      }
+
+      i++;
+      continue;
+    }
+
+    if (stack.length === 1 && top.depth === 0) {
+      mask[i] = 1;
+    }
+
+    i++;
+  }
+
+  return mask;
+}
+
+/**
+ * @param {Uint8Array} mask
+ * @param {number} index
+ */
+function isTopLevelAt(mask, index) {
+  return mask[index] === 1;
+}
+
+/**
+ * Offset of the first non-whitespace character on a line.
+ *
+ * @param {string} line
+ */
+function indentOf(line) {
+  const match = /\S/.exec(line);
+
+  return match ? match.index : 0;
+}
+
+/**
+ * @param {string | undefined} ch
+ */
+function isWordChar(ch) {
+  return ch !== undefined && /[\w$]/.test(ch);
 }
 
 /**
@@ -279,19 +446,19 @@ export function buildGmdModule({
 
   const mergedImports = mergeImports(importGroups).join('\n');
 
-  /** @type {string[]} */
-  const preludeLines = [];
-
-  if (scope && scope.keys.length) {
-    preludeLines.push(`const { ${scope.keys.join(', ')} } = __scope__;`);
-  }
-
-  const allScopeIdents = scope && scope.keys.length ? [...scope.keys, ...scopeIdents] : scopeIdents;
-  const scopeBody = allScopeIdents.length ? `{ ${allScopeIdents.join(', ')} }` : `{}`;
+  // Scope keys stay behind `__scope__.` rather than being destructured into
+  // module scope. Demo imports are hoisted into this same module, and the
+  // default scope keys (`on`, `fn`, `get`, `hash`, `array`, `concat`) are
+  // exactly the names a demo is most likely to import from `@ember/modifier`
+  // or `@ember/helper` — destructuring makes that pair a duplicate
+  // declaration and the whole module dies with a SyntaxError.
+  const scopeEntries =
+    scope && scope.keys.length ? scope.keys.map((key) => `${key}: __scope__.${key}`) : [];
+  const allScopeEntries = [...scopeEntries, ...scopeIdents];
+  const scopeBody = allScopeEntries.length ? `{ ${allScopeEntries.join(', ')} }` : `{}`;
 
   return (
     `${mergedImports}\n\n` +
-    (preludeLines.length ? preludeLines.join('\n') + '\n\n' : '') +
     (bodyDecls.length ? bodyDecls.join('\n\n') + '\n\n' : '') +
     `const _component = template(${JSON.stringify(rewrittenProse)}, {\n` +
     `  scope: () => (${scopeBody}),\n` +
@@ -320,6 +487,10 @@ export function replacePlaceholder(html, id, name) {
   return html.replace(pattern, (_match, _attr, classes) => {
     const classAttr = classes !== undefined ? ` class="${classes}"` : '';
 
-    return `<div${classAttr}><${name} /></div>`;
+    // The inner `data-repl-output` div keeps the DOM shape a separately
+    // rendered island used to produce: callers (and tests) count these to
+    // find rendered demos, and inlining the demo must not change what they
+    // see.
+    return `<div${classAttr}><div data-repl-output><${name} /></div></div>`;
   });
 }

--- a/packages/repl-sdk/src/render-to-string.js
+++ b/packages/repl-sdk/src/render-to-string.js
@@ -11,6 +11,8 @@
  * transforms every demo through it), so the merge runs through babel too.
  */
 
+import { assert } from './utils.js';
+
 const PARSER_PLUGINS = ['importAttributes'];
 
 /**
@@ -32,12 +34,18 @@ const PARSER_PLUGINS = ['importAttributes'];
  * demos see only what the emitted module itself imports.
  *
  * @param {object} args
- * @param {any} args.babel - `@babel/standalone`
+ * @param {any} [args.babel] - `@babel/standalone`, required only to inline demos
  * @param {string} args.prose - Markdown rendered to HTML, with demo placeholders
  * @param {Demo[]} [args.demos]
  * @returns {string}
  */
 export function buildGmdModule({ babel, prose, demos = [] }) {
+  assert(
+    `Inlining ${demos.length} live demo(s) needs '@babel/standalone'. ` +
+      `Provide it through the compiler's resolve config, the way ember-repl does.`,
+    babel || !demos.length
+  );
+
   const imports = new ImportRegistry();
   const templateLocal = imports.use('@ember/template-compiler', 'named', 'template', 'template');
 

--- a/packages/repl-sdk/src/render-to-string.js
+++ b/packages/repl-sdk/src/render-to-string.js
@@ -1,466 +1,67 @@
 /**
- * Shared helpers for the build-time `renderToString` code path.
+ * Assembly for the build-time `renderToString` output.
  *
- * The job of these helpers is purely lexical — given the JS source emitted by
- * a sub-compiler (e.g. gjs/hbs), split it into top-level imports + body so
- * the caller (e.g. `gmd`) can merge many such modules into one self-contained
- * module string that the host app's own bundler will then process.
+ * `renderToString` has to hand back a single self-contained module, so every
+ * live demo in a gmd document is compiled to source and inlined next to the
+ * prose. Demos are independent modules that know nothing about each other, so
+ * merging them means resolving import collisions and top-level name
+ * collisions — work that needs real scope information, not text matching.
  *
- * Nothing here parses JS into an AST — the input is expected to be the
- * deterministic output of babel + content-tag, where imports are top-level
- * and the module ends with a single `export default <expr>;`.
+ * Babel is already loaded and running in this path (the gjs compiler
+ * transforms every demo through it), so the merge runs through babel too.
+ */
+
+const PARSER_PLUGINS = ['importAttributes'];
+
+/**
+ * @typedef {object} Demo
+ * @property {string} name - Identifier the prose invokes, e.g. `Demo1`
+ * @property {string} placeholderId - id of the div this demo replaces
+ * @property {string} source - The demo's compiled JS module source
  */
 
 /**
- * @typedef {object} ModuleParts
- * @property {string[]} imports - Top-level import statements (each ending in `;`)
- * @property {string} body - Remaining module body with imports removed and
- *   `export default <expr>;` rewritten to `return <expr>;`
- */
-
-/**
- * Split a JS module source into its top-level import statements and the rest
- * of its body, rewriting any trailing `export default <expr>;` to a `return`
- * so the body is suitable for IIFE-wrapping.
- *
- * Multi-line imports (`import {\n  a,\n  b\n} from 'x';`) are supported by
- * brace-balanced continuation across lines.
- *
- * @param {string} source
- * @returns {ModuleParts}
- */
-export function splitModule(source) {
-  const lines = source.split('\n');
-  const topLevel = topLevelMask(source);
-  /** @type {string[]} */
-  const imports = [];
-  /** @type {string[]} */
-  const bodyLines = [];
-
-  let i = 0;
-  let offset = 0;
-
-  while (i < lines.length) {
-    const line = /** @type {string} */ (lines[i]);
-    const lineStart = offset;
-
-    offset += line.length + 1;
-
-    // A demo that quotes Ember code (the "build your own REPL" sample assigns
-    // a whole component to a template literal) has `import …` at column 0
-    // inside that literal. Hoisting those lines out silently strips the
-    // quoted module's own imports, so gate on real top-level position.
-    if (!isImportStart(line) || !isTopLevelAt(topLevel, lineStart + indentOf(line))) {
-      bodyLines.push(line);
-      i++;
-      continue;
-    }
-
-    let chunk = line;
-    let depth = braceDelta(line);
-    let parenDepth = parenDelta(line);
-
-    while (
-      i + 1 < lines.length &&
-      (depth > 0 || parenDepth > 0 || !chunk.trimEnd().endsWith(';'))
-    ) {
-      i++;
-
-      const next = /** @type {string} */ (lines[i]);
-
-      offset += next.length + 1;
-      chunk += '\n' + next;
-      depth += braceDelta(next);
-      parenDepth += parenDelta(next);
-    }
-
-    imports.push(chunk);
-    i++;
-  }
-
-  const body = rewriteDefaultExport(bodyLines.join('\n'));
-
-  return { imports, body };
-}
-
-/**
- * @param {string} line
- */
-function isImportStart(line) {
-  return /^\s*import(\s|\s*['"`{*])/.test(line);
-}
-
-/**
- * Count `{` − `}` in a line, ignoring chars inside strings or line comments.
- * Good enough for the small set of characters babel emits inside an import
- * statement (no template literals, no regex literals).
- *
- * @param {string} line
- */
-function braceDelta(line) {
-  return countCharsOutsideStrings(line, '{', '}');
-}
-
-/**
- * @param {string} line
- */
-function parenDelta(line) {
-  return countCharsOutsideStrings(line, '(', ')');
-}
-
-/**
- * @param {string} line
- * @param {string} open
- * @param {string} close
- */
-function countCharsOutsideStrings(line, open, close) {
-  let depth = 0;
-  /** @type {string | null} */
-  let stringChar = null;
-
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i];
-
-    if (stringChar) {
-      if (ch === '\\') {
-        i++;
-        continue;
-      }
-
-      if (ch === stringChar) {
-        stringChar = null;
-      }
-
-      continue;
-    }
-
-    if (ch === '"' || ch === "'" || ch === '`') {
-      stringChar = ch;
-      continue;
-    }
-
-    if (ch === '/' && line[i + 1] === '/') break;
-
-    if (ch === open) depth++;
-    else if (ch === close) depth--;
-  }
-
-  return depth;
-}
-
-/**
- * Rewrite the final `export default <expr>;` to `return <expr>;` so the
- * caller can wrap the body in an IIFE.
- *
- * If there is no `export default`, the body is returned unchanged.
- *
- * @param {string} body
- * @returns {string}
- */
-function rewriteDefaultExport(body) {
-  const found = findTopLevelExportDefault(body);
-
-  if (!found) {
-    return body;
-  }
-
-  const before = body.slice(0, found.index);
-  const after = body.slice(found.index + found.length);
-
-  return `${before}return ${after}`;
-}
-
-/**
- * Locate the module's own `export default`, skipping any that appear inside
- * strings, template literals, or comments.
- *
- * A line-anchored regex is not enough: a demo that shows Ember code as a
- * string (the "build your own REPL" sample assigns a whole component to a
- * template literal) has `export default` at column 0 *inside* that literal.
- * Rewriting there corrupts the string and leaves the real export in place,
- * so the IIFE wrapper dies with "Unexpected token 'export'".
- *
- * @param {string} body
- * @returns {{ index: number, length: number } | null}
- */
-function findTopLevelExportDefault(body) {
-  const topLevel = topLevelMask(body);
-  const pattern = /export\s+default\s+/g;
-
-  /** @type {RegExpExecArray | null} */
-  let match;
-
-  while ((match = pattern.exec(body)) !== null) {
-    if (isTopLevelAt(topLevel, match.index) && !isWordChar(body[match.index - 1])) {
-      return { index: match.index, length: match[0].length };
-    }
-  }
-
-  return null;
-}
-
-/**
- * Mark every offset in `source` that sits in top-level module code — outside
- * any string, template literal, or comment, and at brace depth zero.
- *
- * Everything that rewrites a module by position depends on this: both the
- * import hoist and the `export default` rewrite would otherwise fire on text
- * that merely looks like code because a demo quoted it.
- *
- * @param {string} source
- * @returns {Uint8Array}
- */
-function topLevelMask(source) {
-  const mask = new Uint8Array(source.length);
-  /** @type {Array<{ type: 'code' | 'sq' | 'dq' | 'tpl', depth: number }>} */
-  const stack = [{ type: 'code', depth: 0 }];
-  let i = 0;
-
-  while (i < source.length) {
-    const top = /** @type {{ type: string, depth: number }} */ (stack[stack.length - 1]);
-    const ch = source[i];
-
-    if (top.type === 'sq' || top.type === 'dq') {
-      if (ch === '\\') {
-        i += 2;
-        continue;
-      }
-
-      if ((top.type === 'sq' && ch === "'") || (top.type === 'dq' && ch === '"')) {
-        stack.pop();
-      }
-
-      i++;
-      continue;
-    }
-
-    if (top.type === 'tpl') {
-      if (ch === '\\') {
-        i += 2;
-        continue;
-      }
-
-      if (ch === '`') {
-        stack.pop();
-        i++;
-        continue;
-      }
-
-      // `${` opens a nested code context that can itself contain strings
-      if (ch === '$' && source[i + 1] === '{') {
-        stack.push({ type: 'code', depth: 0 });
-        i += 2;
-        continue;
-      }
-
-      i++;
-      continue;
-    }
-
-    if (ch === '/' && source[i + 1] === '/') {
-      const newline = source.indexOf('\n', i);
-
-      i = newline === -1 ? source.length : newline;
-      continue;
-    }
-
-    if (ch === '/' && source[i + 1] === '*') {
-      const end = source.indexOf('*/', i + 2);
-
-      i = end === -1 ? source.length : end + 2;
-      continue;
-    }
-
-    if (ch === "'" || ch === '"' || ch === '`') {
-      stack.push({ type: ch === "'" ? 'sq' : ch === '"' ? 'dq' : 'tpl', depth: 0 });
-      i++;
-      continue;
-    }
-
-    if (ch === '{') {
-      top.depth++;
-      i++;
-      continue;
-    }
-
-    if (ch === '}') {
-      // depth 0 inside a nested context means this `}` closes a `${`
-      if (top.depth === 0 && stack.length > 1) {
-        stack.pop();
-      } else {
-        top.depth--;
-      }
-
-      i++;
-      continue;
-    }
-
-    if (stack.length === 1 && top.depth === 0) {
-      mask[i] = 1;
-    }
-
-    i++;
-  }
-
-  return mask;
-}
-
-/**
- * @param {Uint8Array} mask
- * @param {number} index
- */
-function isTopLevelAt(mask, index) {
-  return mask[index] === 1;
-}
-
-/**
- * Offset of the first non-whitespace character on a line.
- *
- * @param {string} line
- */
-function indentOf(line) {
-  const match = /\S/.exec(line);
-
-  return match ? match.index : 0;
-}
-
-/**
- * @param {string | undefined} ch
- */
-function isWordChar(ch) {
-  return ch !== undefined && /[\w$]/.test(ch);
-}
-
-/**
- * Deduplicate a list of import statements by their exact textual content
- * (after trimming trailing whitespace). This is intentionally conservative —
- * we'd rather emit two equivalent-but-different imports than collapse two
- * imports that bind different things.
- *
- * @param {string[][]} groups
- * @returns {string[]}
- */
-export function mergeImports(groups) {
-  const seen = new Set();
-  /** @type {string[]} */
-  const out = [];
-
-  for (const group of groups) {
-    for (const imp of group) {
-      const key = imp.trim();
-
-      if (seen.has(key)) continue;
-
-      seen.add(key);
-      out.push(imp);
-    }
-  }
-
-  return out;
-}
-
-/**
- * Wrap a module body in an IIFE that returns the (rewritten) default export.
- *
- * @param {string} body
- * @param {string} name
- */
-export function wrapAsConst(body, name) {
-  return `const ${name} = (() => {\n${indent(body)}\n})();`;
-}
-
-/**
- * @param {string} text
- */
-function indent(text) {
-  return text
-    .split('\n')
-    .map((line) => (line.length ? `  ${line}` : line))
-    .join('\n');
-}
-
-/**
- * Inline one or more compiled sub-modules into the surrounding gmd prose,
+ * Inline one or more compiled demo modules into the surrounding gmd prose,
  * producing one self-contained ES module string.
  *
- * The same function is used by both the *runtime* compile path (the module
- * gets blob-eval'd and rendered) and the *renderToString* path (the module
- * gets handed back to the caller's bundler). The only differences are:
+ * The emitted module imports `template` from `@ember/template-compiler` (the
+ * build-time form), so the consuming app's babel pipeline precompiles the
+ * `template(...)` call to wire format.
  *
- *   - `templateModule`: which `template` to import. Use
- *     `'@ember/template-compiler/runtime'` when this module will be
- *     evaluated at runtime, or `'@ember/template-compiler'` when a build-
- *     time babel plugin is expected to precompile the `template(...)` call.
- *
- *   - `scope`: a virtual ES module specifier that the emitted module will
- *     `import * as __scope__ from '<specifier>'`, and the list of keys to
- *     destructure off that namespace. The runtime path registers the live
- *     scope object behind such a specifier via `api.provide`; the
- *     renderToString path passes `null` because there is no live scope to
- *     bridge.
- *
- * The placeholders in `prose` are replaced with `<name />` Glimmer
- * invocations wrapped in a div that preserves the original placeholder's
- * `class` attribute (e.g. `repl-sdk__demo`) so existing CSS still applies.
- *
- * This is a pure function — the caller is responsible for driving the
- * sub-compiles and (for the runtime path) for registering the scope value
- * behind `scope.specifier` before this output is evaluated.
+ * There is no live scope: a runtime object cannot be written into source, so
+ * demos see only what the emitted module itself imports.
  *
  * @param {object} args
- * @param {string} args.prose
- * @param {Array<{ name: string, placeholderId: string, source: string }>} args.demos
- * @param {string} [args.templateModule]
- * @param {{ specifier: string, keys: string[] } | null} [args.scope]
+ * @param {any} args.babel - `@babel/standalone`
+ * @param {string} args.prose - Markdown rendered to HTML, with demo placeholders
+ * @param {Demo[]} [args.demos]
  * @returns {string}
  */
-export function buildGmdModule({
-  prose,
-  demos,
-  templateModule = '@ember/template-compiler',
-  scope = null,
-}) {
-  /** @type {string[][]} */
-  const importGroups = [[`import { template } from '${templateModule}';`]];
-
-  if (scope && scope.keys.length) {
-    importGroups.push([`import * as __scope__ from '${scope.specifier}';`]);
-  }
+export function buildGmdModule({ babel, prose, demos = [] }) {
+  const imports = new ImportRegistry();
+  const templateLocal = imports.use('@ember/template-compiler', 'named', 'template', 'template');
 
   /** @type {string[]} */
-  const bodyDecls = [];
+  const declarations = [];
   /** @type {string[]} */
-  const scopeIdents = [];
+  const demoNames = [];
 
   let rewrittenProse = prose;
 
-  for (const demo of demos) {
-    const { imports, body } = splitModule(demo.source);
+  demos.forEach((demo, index) => {
+    const body = inlineDemo({ babel, source: demo.source, index, imports });
 
-    importGroups.push(imports);
-    bodyDecls.push(wrapAsConst(body, demo.name));
-    scopeIdents.push(demo.name);
-
+    declarations.push(`const ${demo.name} = (() => {\n${indent(body)}\n})();`);
+    demoNames.push(demo.name);
     rewrittenProse = replacePlaceholder(rewrittenProse, demo.placeholderId, demo.name);
-  }
+  });
 
-  const mergedImports = mergeImports(importGroups).join('\n');
-
-  // Scope keys stay behind `__scope__.` rather than being destructured into
-  // module scope. Demo imports are hoisted into this same module, and the
-  // default scope keys (`on`, `fn`, `get`, `hash`, `array`, `concat`) are
-  // exactly the names a demo is most likely to import from `@ember/modifier`
-  // or `@ember/helper` — destructuring makes that pair a duplicate
-  // declaration and the whole module dies with a SyntaxError.
-  const scopeEntries =
-    scope && scope.keys.length ? scope.keys.map((key) => `${key}: __scope__.${key}`) : [];
-  const allScopeEntries = [...scopeEntries, ...scopeIdents];
-  const scopeBody = allScopeEntries.length ? `{ ${allScopeEntries.join(', ')} }` : `{}`;
+  const scopeBody = demoNames.length ? `{ ${demoNames.join(', ')} }` : `{}`;
 
   return (
-    `${mergedImports}\n\n` +
-    (bodyDecls.length ? bodyDecls.join('\n\n') + '\n\n' : '') +
-    `const _component = template(${JSON.stringify(rewrittenProse)}, {\n` +
+    `${imports.toSource()}\n\n` +
+    (declarations.length ? declarations.join('\n\n') + '\n\n' : '') +
+    `const _component = ${templateLocal}(${JSON.stringify(rewrittenProse)}, {\n` +
     `  scope: () => (${scopeBody}),\n` +
     `});\n` +
     `export default _component;\n`
@@ -468,10 +69,263 @@ export function buildGmdModule({
 }
 
 /**
- * Replace the single `<div id="${id}" class="…"></div>` placeholder emitted
- * by `liveCodeExtraction` with a Glimmer component invocation. The wrapping
- * div is preserved (sans `id`) so the `repl-sdk__demo` (or
- * caller-supplied) class still styles the demo container.
+ * Strip a demo module down to a body suitable for IIFE-wrapping:
+ *
+ * - every top-level binding is renamed to a per-demo prefix, so two demos (or
+ *   a demo and the prose module) can declare the same name
+ * - imports are lifted into the shared registry, and their local references
+ *   rewritten to whatever local the registry assigned
+ * - `export default X` becomes a `const` the wrapper returns; other exports
+ *   lose their `export` keyword and stay as plain declarations
+ *
+ * @param {object} args
+ * @param {any} args.babel
+ * @param {string} args.source
+ * @param {number} args.index
+ * @param {ImportRegistry} args.imports
+ * @returns {string}
+ */
+function inlineDemo({ babel, source, index, imports }) {
+  const t = babel.packages.types;
+  const resultName = `_demo${index}_default`;
+
+  let hasDefault = false;
+
+  const plugin = () => ({
+    visitor: {
+      /** @param {any} path */
+      Program(path) {
+        // Imports first, while their bindings still exist: each specifier is
+        // pointed at whatever local the shared registry assigned, so two demos
+        // importing the same thing end up on one declaration.
+        for (const statement of path.get('body')) {
+          if (!statement.isImportDeclaration()) continue;
+
+          const from = statement.node.source.value;
+
+          for (const specifier of statement.node.specifiers) {
+            const local = specifier.local.name;
+            /** @type {string} */
+            let shared;
+
+            if (t.isImportDefaultSpecifier(specifier)) {
+              shared = imports.use(from, 'default', null, local);
+            } else if (t.isImportNamespaceSpecifier(specifier)) {
+              shared = imports.use(from, 'namespace', null, local);
+            } else {
+              const imported = specifier.imported;
+              const name = t.isIdentifier(imported) ? imported.name : imported.value;
+
+              shared = imports.use(from, 'named', name, name);
+            }
+
+            path.scope.rename(local, shared);
+          }
+
+          statement.remove();
+        }
+
+        // Whatever the demo declares for itself gets a per-demo prefix, so two
+        // demos can each define `value` (or `Greeting`) without colliding once
+        // both bodies live in the same module. Crawl first: the import
+        // bindings are gone now, and those names must stay as the registry
+        // assigned them.
+        path.scope.crawl();
+
+        for (const name of Object.keys(path.scope.bindings)) {
+          path.scope.rename(name, `_demo${index}_${name}`);
+        }
+
+        for (const statement of path.get('body')) {
+          if (statement.isExportDefaultDeclaration()) {
+            hasDefault = true;
+
+            const declaration = statement.node.declaration;
+            const expression =
+              t.isFunctionDeclaration(declaration) || t.isClassDeclaration(declaration)
+                ? t.toExpression(declaration)
+                : declaration;
+
+            statement.replaceWith(
+              t.variableDeclaration('const', [
+                t.variableDeclarator(t.identifier(resultName), expression),
+              ])
+            );
+            continue;
+          }
+
+          if (statement.isExportNamedDeclaration()) {
+            if (statement.node.declaration) {
+              statement.replaceWith(statement.node.declaration);
+            } else {
+              statement.remove();
+            }
+
+            continue;
+          }
+
+          if (statement.isExportAllDeclaration()) {
+            statement.remove();
+          }
+        }
+      },
+    },
+  });
+
+  const result = babel.transform(source, {
+    plugins: [plugin],
+    sourceType: 'module',
+    configFile: false,
+    babelrc: false,
+    compact: false,
+    parserOpts: { plugins: PARSER_PLUGINS },
+  });
+
+  const code = result?.code ?? '';
+
+  return hasDefault ? `${code}\n\nreturn ${resultName};` : code;
+}
+
+/**
+ * @typedef {object} ImportEntry
+ * @property {string} from
+ * @property {'default' | 'namespace' | 'named'} kind
+ * @property {string | null} imported
+ * @property {string} local
+ */
+
+/**
+ * Collects every import the merged module needs, collapsing repeats.
+ *
+ * Two demos importing the same binding from the same module share one local.
+ * The same name from *different* modules is suffixed rather than merged.
+ */
+class ImportRegistry {
+  /** @type {Map<string, string>} */
+  #byKey = new Map();
+
+  /** @type {Set<string>} */
+  #taken = new Set();
+
+  /** @type {ImportEntry[]} */
+  #entries = [];
+
+  /**
+   * @param {string} from
+   * @param {'default' | 'namespace' | 'named'} kind
+   * @param {string | null} imported
+   * @param {string} [preferred] - name the source module used, kept when free
+   * @returns {string} the local identifier to reference this import by
+   */
+  use(from, kind, imported, preferred) {
+    const key = JSON.stringify([from, kind, imported]);
+    const existing = this.#byKey.get(key);
+
+    if (existing) return existing;
+
+    const local = this.#claim(preferred ? toIdentifier(preferred) : preferredName(from, kind));
+
+    this.#byKey.set(key, local);
+    this.#entries.push({ from, kind, imported, local });
+
+    return local;
+  }
+
+  /**
+   * @param {string} preferred
+   */
+  #claim(preferred) {
+    if (!this.#taken.has(preferred)) {
+      this.#taken.add(preferred);
+
+      return preferred;
+    }
+
+    let n = 1;
+
+    while (this.#taken.has(`${preferred}$${n}`)) n++;
+
+    const local = `${preferred}$${n}`;
+
+    this.#taken.add(local);
+
+    return local;
+  }
+
+  /**
+   * @returns {string}
+   */
+  toSource() {
+    /** @type {Map<string, ImportEntry[]>} */
+    const bySource = new Map();
+
+    for (const entry of this.#entries) {
+      const group = bySource.get(entry.from) ?? [];
+
+      group.push(entry);
+      bySource.set(entry.from, group);
+    }
+
+    /** @type {string[]} */
+    const lines = [];
+
+    for (const [from, group] of bySource) {
+      const namespaces = group.filter((e) => e.kind === 'namespace');
+      const defaults = group.filter((e) => e.kind === 'default');
+      const named = group.filter((e) => e.kind === 'named');
+
+      // A namespace import cannot share a declaration with named imports
+      for (const entry of namespaces) {
+        lines.push(`import * as ${entry.local} from '${from}';`);
+      }
+
+      const clauses = [];
+
+      if (defaults[0]) clauses.push(defaults[0].local);
+
+      if (named.length) {
+        const specifiers = named.map((e) =>
+          e.imported === e.local ? e.local : `${e.imported} as ${e.local}`
+        );
+
+        clauses.push(`{ ${specifiers.join(', ')} }`);
+      }
+
+      if (clauses.length) {
+        lines.push(`import ${clauses.join(', ')} from '${from}';`);
+      }
+    }
+
+    return lines.join('\n');
+  }
+}
+
+/**
+ * @param {string} from
+ * @param {string} kind
+ */
+function preferredName(from, kind) {
+  const base = toIdentifier(from.split('/').filter(Boolean).pop() ?? 'mod');
+
+  return kind === 'namespace' ? `${base}Ns` : base;
+}
+
+/**
+ * @param {string} value
+ */
+function toIdentifier(value) {
+  const cleaned = value.replace(/[^\w$]/g, '_').replace(/^(\d)/, '_$1');
+
+  return cleaned || '_mod';
+}
+
+/**
+ * Replace the `<div id="${id}" class="…"></div>` placeholder emitted by
+ * `liveCodeExtraction` with a Glimmer component invocation.
+ *
+ * The placeholder div is preserved (sans `id`) so `repl-sdk__demo` styling
+ * still applies, and the inner `data-repl-output` div matches the DOM the
+ * runtime path produces, so callers can find demos the same way in both.
  *
  * @param {string} html
  * @param {string} id
@@ -487,10 +341,16 @@ export function replacePlaceholder(html, id, name) {
   return html.replace(pattern, (_match, _attr, classes) => {
     const classAttr = classes !== undefined ? ` class="${classes}"` : '';
 
-    // The inner `data-repl-output` div keeps the DOM shape a separately
-    // rendered island used to produce: callers (and tests) count these to
-    // find rendered demos, and inlining the demo must not change what they
-    // see.
     return `<div${classAttr}><div data-repl-output><${name} /></div></div>`;
   });
+}
+
+/**
+ * @param {string} text
+ */
+function indent(text) {
+  return text
+    .split('\n')
+    .map((line) => (line.trim() ? `  ${line}` : line))
+    .join('\n');
 }

--- a/packages/repl-sdk/src/render-to-string.test.ts
+++ b/packages/repl-sdk/src/render-to-string.test.ts
@@ -189,19 +189,19 @@ describe('buildGmdModule', () => {
     expect(out).toMatch(/export default _component;/);
   });
 
-  test('runtime form: imports runtime template-compiler and threads live scope', () => {
+  test('runtime form: imports runtime template-compiler and threads scope via a virtual module specifier', () => {
     const out = buildGmdModule({
       prose: `<h1>Hello</h1>`,
       demos: [],
       templateModule: '@ember/template-compiler/runtime',
       scope: {
-        expression: `globalThis[Symbol.for('repl-sdk:gmd-scope:42')]`,
+        specifier: 'repl-sdk:gmd-scope:42',
         keys: ['array', 'concat'],
       },
     });
 
     expect(out).toContain(`import { template } from '@ember/template-compiler/runtime';`);
-    expect(out).toContain(`const __scope__ = globalThis[Symbol.for('repl-sdk:gmd-scope:42')];`);
+    expect(out).toContain(`import * as __scope__ from 'repl-sdk:gmd-scope:42';`);
     expect(out).toContain(`const { array, concat } = __scope__;`);
     // Live scope keys spread into the template scope
     expect(out).toMatch(/scope: \(\) => \(\{ array, concat \}\)/);
@@ -248,7 +248,7 @@ describe('buildGmdModule', () => {
       demos: [{ name: 'Demo1', placeholderId: 'a', source: make(1) }],
       templateModule: '@ember/template-compiler/runtime',
       scope: {
-        expression: `globalThis[Symbol.for('repl-sdk:gmd-scope:7')]`,
+        specifier: 'repl-sdk:gmd-scope:7',
         keys: ['on'],
       },
     });

--- a/packages/repl-sdk/src/render-to-string.test.ts
+++ b/packages/repl-sdk/src/render-to-string.test.ts
@@ -123,18 +123,18 @@ describe('wrapAsConst', () => {
 });
 
 describe('replacePlaceholder', () => {
-  test('replaces div by id with a component invocation', () => {
-    const html = `<p>before</p><div id="repl_1" class="demo"></div><p>after</p>`;
+  test('preserves the placeholder div + class, wraps a component invocation', () => {
+    const html = `<p>before</p><div id="repl_1" class="repl-sdk__demo"></div><p>after</p>`;
     const out = replacePlaceholder(html, 'repl_1', 'Demo1');
 
-    expect(out).toBe(`<p>before</p><Demo1 /><p>after</p>`);
+    expect(out).toBe(`<p>before</p><div class="repl-sdk__demo"><Demo1 /></div><p>after</p>`);
   });
 
   test('escapes regex metacharacters in the id', () => {
     const html = `<div id="a.b.c" class=""></div>`;
     const out = replacePlaceholder(html, 'a.b.c', 'Demo1');
 
-    expect(out).toBe(`<Demo1 />`);
+    expect(out).toBe(`<div class=""><Demo1 /></div>`);
   });
 
   test('does not touch divs with different ids', () => {
@@ -144,10 +144,17 @@ describe('replacePlaceholder', () => {
     expect(out).toContain(`<div id="other">`);
     expect(out).toContain(`<Demo1 />`);
   });
+
+  test('omits class attribute when the placeholder had none', () => {
+    const html = `<div id="x"></div>`;
+    const out = replacePlaceholder(html, 'x', 'Demo1');
+
+    expect(out).toBe(`<div><Demo1 /></div>`);
+  });
 });
 
 describe('buildGmdModule', () => {
-  test('inlines one demo end-to-end', () => {
+  test('build-time form: inlines one demo with build-time template-compiler', () => {
     const demoSource = [
       `import Component from '@glimmer/component';`,
       `import { template } from '@ember/template-compiler';`,
@@ -163,21 +170,41 @@ describe('buildGmdModule', () => {
       demos: [{ name: 'Demo1', placeholderId: 'repl_1', source: demoSource }],
     });
 
-    // Imports are hoisted + deduped — @ember/template-compiler appears once
-    const importMatches = out.match(/import \{ template \} from '@ember\/template-compiler';/g);
-
-    expect(importMatches?.length).toBe(1);
+    // build-time `template` is the default
+    expect(out).toContain(`import { template } from '@ember/template-compiler';`);
+    // Demo's own template-compiler import is deduped against the prose's
+    expect(out.match(/import \{ template \} from '@ember\/template-compiler';/g)?.length).toBe(1);
     expect(out).toContain(`import Component from '@glimmer/component';`);
 
-    // The demo body is wrapped in a named IIFE
+    // Demo body wrapped in a named IIFE and referenced from prose. The
+    // prose lives inside a `template(JSON.stringify(...))` call, so double-
+    // quotes in the rewritten div are JSON-escaped.
     expect(out).toMatch(/const Demo1 = \(\(\) => \{[\s\S]*\}\)\(\);/);
-    // …and references it from the prose
-    expect(out).toContain(`<Demo1 />`);
+    expect(out).toContain(`<div class=\\"demo\\"><Demo1 /></div>`);
     expect(out).not.toContain(`<div id="repl_1"`);
+    expect(out).not.toContain(`<div id=\\"repl_1\\"`);
 
-    // The trailing template() call passes Demo1 into scope
+    // Scope contains only Demo1
     expect(out).toMatch(/scope: \(\) => \(\{ Demo1 \}\)/);
     expect(out).toMatch(/export default _component;/);
+  });
+
+  test('runtime form: imports runtime template-compiler and threads live scope', () => {
+    const out = buildGmdModule({
+      prose: `<h1>Hello</h1>`,
+      demos: [],
+      templateModule: '@ember/template-compiler/runtime',
+      scope: {
+        expression: `globalThis[Symbol.for('repl-sdk:gmd-scope:42')]`,
+        keys: ['array', 'concat'],
+      },
+    });
+
+    expect(out).toContain(`import { template } from '@ember/template-compiler/runtime';`);
+    expect(out).toContain(`const __scope__ = globalThis[Symbol.for('repl-sdk:gmd-scope:42')];`);
+    expect(out).toContain(`const { array, concat } = __scope__;`);
+    // Live scope keys spread into the template scope
+    expect(out).toMatch(/scope: \(\) => \(\{ array, concat \}\)/);
   });
 
   test('handles zero demos', () => {
@@ -188,11 +215,10 @@ describe('buildGmdModule', () => {
 
     expect(out).toContain(`import { template } from '@ember/template-compiler';`);
     expect(out).toMatch(/scope: \(\) => \(\{\}\)/);
-    // No IIFE wrappers when there are no demos
     expect(out).not.toMatch(/const Demo\d+ = /);
   });
 
-  test('emits multiple demos in declaration order', () => {
+  test('emits multiple demos in declaration order, merging shared imports', () => {
     const make = (n: number) =>
       [
         `import Component from '@glimmer/component';`,
@@ -210,7 +236,23 @@ describe('buildGmdModule', () => {
 
     expect(out.indexOf('const Demo1 ')).toBeLessThan(out.indexOf('const Demo2 '));
     expect(out).toMatch(/scope: \(\) => \(\{ Demo1, Demo2 \}\)/);
-    // Common import only appears once across both demos
     expect(out.match(/import Component from '@glimmer\/component';/g)?.length).toBe(1);
+  });
+
+  test('runtime + demos: live-scope keys come before demo names in scope', () => {
+    const make = (n: number) =>
+      [`const _component = ${n};`, `export default _component;`].join('\n');
+
+    const out = buildGmdModule({
+      prose: `<div id="a"></div>`,
+      demos: [{ name: 'Demo1', placeholderId: 'a', source: make(1) }],
+      templateModule: '@ember/template-compiler/runtime',
+      scope: {
+        expression: `globalThis[Symbol.for('repl-sdk:gmd-scope:7')]`,
+        keys: ['on'],
+      },
+    });
+
+    expect(out).toMatch(/scope: \(\) => \(\{ on, Demo1 \}\)/);
   });
 });

--- a/packages/repl-sdk/src/render-to-string.test.ts
+++ b/packages/repl-sdk/src/render-to-string.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  buildGmdModule,
+  mergeImports,
+  replacePlaceholder,
+  splitModule,
+  wrapAsConst,
+} from './render-to-string.js';
+
+describe('splitModule', () => {
+  test('separates single-line imports from body', () => {
+    const source = [
+      `import X from 'x';`,
+      `import { y } from 'y';`,
+      ``,
+      `const _component = makeIt();`,
+      `export default _component;`,
+    ].join('\n');
+
+    const { imports, body } = splitModule(source);
+
+    expect(imports).toEqual([`import X from 'x';`, `import { y } from 'y';`]);
+    expect(body).toContain('const _component = makeIt();');
+    expect(body).toContain('return _component;');
+    expect(body).not.toContain('export default');
+  });
+
+  test('handles multi-line braced imports', () => {
+    const source = [
+      `import {`,
+      `  a,`,
+      `  b,`,
+      `} from 'x';`,
+      ``,
+      `const _component = a;`,
+      `export default _component;`,
+    ].join('\n');
+
+    const { imports, body } = splitModule(source);
+
+    expect(imports).toHaveLength(1);
+    expect(imports[0]).toContain('a,');
+    expect(imports[0]).toContain('b,');
+    expect(body).toContain('return _component;');
+  });
+
+  test('handles side-effect imports with no specifiers', () => {
+    const source = [`import 'side-effect';`, `const k = 1;`, `export default k;`].join('\n');
+
+    const { imports, body } = splitModule(source);
+
+    expect(imports).toEqual([`import 'side-effect';`]);
+    expect(body).toContain('return k;');
+  });
+
+  test('handles import with attributes', () => {
+    const source = [
+      `import data from './x.json' with { type: 'json' };`,
+      `export default data;`,
+    ].join('\n');
+
+    const { imports } = splitModule(source);
+
+    expect(imports).toHaveLength(1);
+    expect(imports[0]).toContain('with');
+  });
+
+  test('rewrites only the last export default', () => {
+    const source = [
+      `import X from 'x';`,
+      `// a comment that mentions export default`,
+      `const v = 1;`,
+      `export default v;`,
+    ].join('\n');
+
+    const { body } = splitModule(source);
+
+    expect(body).toContain('return v;');
+    expect(body).not.toContain('return v;\n');
+    // The comment should still be present (not rewritten)
+    expect(body).toContain('export default');
+    // ...but the original statement is gone — only the comment retains the phrase
+    expect(body.match(/return\s+v/g)?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  test('leaves body unchanged when there is no default export', () => {
+    const source = [`import X from 'x';`, `const v = 1;`].join('\n');
+
+    const { body } = splitModule(source);
+
+    expect(body).not.toContain('return');
+    expect(body).toContain('const v = 1;');
+  });
+});
+
+describe('mergeImports', () => {
+  test('deduplicates exact-match imports', () => {
+    const merged = mergeImports([
+      [`import X from 'x';`, `import { y } from 'y';`],
+      [`import X from 'x';`, `import Z from 'z';`],
+    ]);
+
+    expect(merged).toEqual([`import X from 'x';`, `import { y } from 'y';`, `import Z from 'z';`]);
+  });
+
+  test('does not collapse different specifiers from the same module', () => {
+    const merged = mergeImports([[`import { a } from 'x';`], [`import { b } from 'x';`]]);
+
+    expect(merged).toHaveLength(2);
+  });
+});
+
+describe('wrapAsConst', () => {
+  test('wraps body in an IIFE-returning const', () => {
+    const out = wrapAsConst(`const v = 1;\nreturn v;`, 'Demo1');
+
+    expect(out).toMatch(/^const Demo1 = \(\(\) => \{/);
+    expect(out).toMatch(/\}\)\(\);$/);
+    expect(out).toContain('const v = 1;');
+    expect(out).toContain('return v;');
+  });
+});
+
+describe('replacePlaceholder', () => {
+  test('replaces div by id with a component invocation', () => {
+    const html = `<p>before</p><div id="repl_1" class="demo"></div><p>after</p>`;
+    const out = replacePlaceholder(html, 'repl_1', 'Demo1');
+
+    expect(out).toBe(`<p>before</p><Demo1 /><p>after</p>`);
+  });
+
+  test('escapes regex metacharacters in the id', () => {
+    const html = `<div id="a.b.c" class=""></div>`;
+    const out = replacePlaceholder(html, 'a.b.c', 'Demo1');
+
+    expect(out).toBe(`<Demo1 />`);
+  });
+
+  test('does not touch divs with different ids', () => {
+    const html = `<div id="other"></div><div id="repl_1" class=""></div>`;
+    const out = replacePlaceholder(html, 'repl_1', 'Demo1');
+
+    expect(out).toContain(`<div id="other">`);
+    expect(out).toContain(`<Demo1 />`);
+  });
+});
+
+describe('buildGmdModule', () => {
+  test('inlines one demo end-to-end', () => {
+    const demoSource = [
+      `import Component from '@glimmer/component';`,
+      `import { template } from '@ember/template-compiler';`,
+      `class _Greeting extends Component {`,
+      `  name = 'world';`,
+      `}`,
+      `const _component = template('Hi', { scope: () => ({}) }, _Greeting);`,
+      `export default _component;`,
+    ].join('\n');
+
+    const out = buildGmdModule({
+      prose: `<h1>Hello</h1><div id="repl_1" class="demo"></div>`,
+      demos: [{ name: 'Demo1', placeholderId: 'repl_1', source: demoSource }],
+    });
+
+    // Imports are hoisted + deduped — @ember/template-compiler appears once
+    const importMatches = out.match(/import \{ template \} from '@ember\/template-compiler';/g);
+
+    expect(importMatches?.length).toBe(1);
+    expect(out).toContain(`import Component from '@glimmer/component';`);
+
+    // The demo body is wrapped in a named IIFE
+    expect(out).toMatch(/const Demo1 = \(\(\) => \{[\s\S]*\}\)\(\);/);
+    // …and references it from the prose
+    expect(out).toContain(`<Demo1 />`);
+    expect(out).not.toContain(`<div id="repl_1"`);
+
+    // The trailing template() call passes Demo1 into scope
+    expect(out).toMatch(/scope: \(\) => \(\{ Demo1 \}\)/);
+    expect(out).toMatch(/export default _component;/);
+  });
+
+  test('handles zero demos', () => {
+    const out = buildGmdModule({
+      prose: `<h1>Hello</h1>`,
+      demos: [],
+    });
+
+    expect(out).toContain(`import { template } from '@ember/template-compiler';`);
+    expect(out).toMatch(/scope: \(\) => \(\{\}\)/);
+    // No IIFE wrappers when there are no demos
+    expect(out).not.toMatch(/const Demo\d+ = /);
+  });
+
+  test('emits multiple demos in declaration order', () => {
+    const make = (n: number) =>
+      [
+        `import Component from '@glimmer/component';`,
+        `const _component = ${n};`,
+        `export default _component;`,
+      ].join('\n');
+
+    const out = buildGmdModule({
+      prose: `<div id="a"></div><div id="b"></div>`,
+      demos: [
+        { name: 'Demo1', placeholderId: 'a', source: make(1) },
+        { name: 'Demo2', placeholderId: 'b', source: make(2) },
+      ],
+    });
+
+    expect(out.indexOf('const Demo1 ')).toBeLessThan(out.indexOf('const Demo2 '));
+    expect(out).toMatch(/scope: \(\) => \(\{ Demo1, Demo2 \}\)/);
+    // Common import only appears once across both demos
+    expect(out.match(/import Component from '@glimmer\/component';/g)?.length).toBe(1);
+  });
+});

--- a/packages/repl-sdk/src/render-to-string.test.ts
+++ b/packages/repl-sdk/src/render-to-string.test.ts
@@ -92,6 +92,39 @@ describe('splitModule', () => {
     expect(body).not.toContain('return');
     expect(body).toContain('const v = 1;');
   });
+
+  test('does not hoist import lines out of a template literal', () => {
+    const source = [
+      `import Component from '@glimmer/component';`,
+      'const SAMPLE = `import Component from "@glimmer/component";',
+      `import { tracked } from "@glimmer/tracking";`,
+      '`;',
+      `const _component = SAMPLE;`,
+      `export default _component;`,
+    ].join('\n');
+
+    const { imports, body } = splitModule(source);
+
+    expect(imports).toEqual([`import Component from '@glimmer/component';`]);
+    // The quoted module keeps its own imports
+    expect(body).toContain(`import { tracked } from "@glimmer/tracking";`);
+  });
+
+  test('does not rewrite an export default inside a template literal', () => {
+    const source = [
+      'const SAMPLE = `',
+      `export default class Hello {}`,
+      '`;',
+      `const _component = SAMPLE;`,
+      `export default _component;`,
+    ].join('\n');
+
+    const { body } = splitModule(source);
+
+    expect(body).toContain(`export default class Hello {}`);
+    expect(body).toContain(`return _component;`);
+    expect(body).not.toContain(`return class Hello {}`);
+  });
 });
 
 describe('mergeImports', () => {
@@ -127,14 +160,16 @@ describe('replacePlaceholder', () => {
     const html = `<p>before</p><div id="repl_1" class="repl-sdk__demo"></div><p>after</p>`;
     const out = replacePlaceholder(html, 'repl_1', 'Demo1');
 
-    expect(out).toBe(`<p>before</p><div class="repl-sdk__demo"><Demo1 /></div><p>after</p>`);
+    expect(out).toBe(
+      `<p>before</p><div class="repl-sdk__demo"><div data-repl-output><Demo1 /></div></div><p>after</p>`
+    );
   });
 
   test('escapes regex metacharacters in the id', () => {
     const html = `<div id="a.b.c" class=""></div>`;
     const out = replacePlaceholder(html, 'a.b.c', 'Demo1');
 
-    expect(out).toBe(`<div class=""><Demo1 /></div>`);
+    expect(out).toBe(`<div class=""><div data-repl-output><Demo1 /></div></div>`);
   });
 
   test('does not touch divs with different ids', () => {
@@ -149,7 +184,7 @@ describe('replacePlaceholder', () => {
     const html = `<div id="x"></div>`;
     const out = replacePlaceholder(html, 'x', 'Demo1');
 
-    expect(out).toBe(`<div><Demo1 /></div>`);
+    expect(out).toBe(`<div><div data-repl-output><Demo1 /></div></div>`);
   });
 });
 
@@ -180,7 +215,7 @@ describe('buildGmdModule', () => {
     // prose lives inside a `template(JSON.stringify(...))` call, so double-
     // quotes in the rewritten div are JSON-escaped.
     expect(out).toMatch(/const Demo1 = \(\(\) => \{[\s\S]*\}\)\(\);/);
-    expect(out).toContain(`<div class=\\"demo\\"><Demo1 /></div>`);
+    expect(out).toContain(`<div class=\\"demo\\"><div data-repl-output><Demo1 /></div></div>`);
     expect(out).not.toContain(`<div id="repl_1"`);
     expect(out).not.toContain(`<div id=\\"repl_1\\"`);
 
@@ -202,9 +237,12 @@ describe('buildGmdModule', () => {
 
     expect(out).toContain(`import { template } from '@ember/template-compiler/runtime';`);
     expect(out).toContain(`import * as __scope__ from 'repl-sdk:gmd-scope:42';`);
-    expect(out).toContain(`const { array, concat } = __scope__;`);
-    // Live scope keys spread into the template scope
-    expect(out).toMatch(/scope: \(\) => \(\{ array, concat \}\)/);
+    // Read through the namespace rather than destructuring: demo imports land
+    // in this same module and would collide with names like `on` or `fn`.
+    expect(out).not.toContain(`const { array, concat } = __scope__;`);
+    expect(out).toMatch(
+      /scope: \(\) => \(\{ array: __scope__\.array, concat: __scope__\.concat \}\)/
+    );
   });
 
   test('handles zero demos', () => {
@@ -253,6 +291,6 @@ describe('buildGmdModule', () => {
       },
     });
 
-    expect(out).toMatch(/scope: \(\) => \(\{ on, Demo1 \}\)/);
+    expect(out).toMatch(/scope: \(\) => \(\{ on: __scope__\.on, Demo1 \}\)/);
   });
 });

--- a/packages/repl-sdk/src/render-to-string.test.ts
+++ b/packages/repl-sdk/src/render-to-string.test.ts
@@ -44,6 +44,22 @@ describe('replacePlaceholder', () => {
 });
 
 describe('buildGmdModule', () => {
+  test('needs no babel when the document has no live demos', () => {
+    const out = buildGmdModule({ prose: `<h1>Hello</h1>`, demos: [] });
+
+    expect(out).toContain(`import { template } from '@ember/template-compiler';`);
+    expect(out).toMatch(/scope: \(\) => \(\{\}\)/);
+  });
+
+  test('reports a missing babel rather than failing deep in the merge', () => {
+    expect(() =>
+      buildGmdModule({
+        prose: `<div id="a"></div>`,
+        demos: [{ name: 'Demo1', placeholderId: 'a', source: `export default 1;` }],
+      })
+    ).toThrow(/@babel\/standalone/);
+  });
+
   test('emits a build-time template import and an empty scope with no demos', () => {
     const out = build(`<h1>Hello</h1>`, []);
 

--- a/packages/repl-sdk/src/render-to-string.test.ts
+++ b/packages/repl-sdk/src/render-to-string.test.ts
@@ -1,159 +1,14 @@
+import babel from '@babel/standalone';
 import { describe, expect, test } from 'vitest';
 
-import {
-  buildGmdModule,
-  mergeImports,
-  replacePlaceholder,
-  splitModule,
-  wrapAsConst,
-} from './render-to-string.js';
+import { buildGmdModule, replacePlaceholder } from './render-to-string.js';
 
-describe('splitModule', () => {
-  test('separates single-line imports from body', () => {
-    const source = [
-      `import X from 'x';`,
-      `import { y } from 'y';`,
-      ``,
-      `const _component = makeIt();`,
-      `export default _component;`,
-    ].join('\n');
-
-    const { imports, body } = splitModule(source);
-
-    expect(imports).toEqual([`import X from 'x';`, `import { y } from 'y';`]);
-    expect(body).toContain('const _component = makeIt();');
-    expect(body).toContain('return _component;');
-    expect(body).not.toContain('export default');
-  });
-
-  test('handles multi-line braced imports', () => {
-    const source = [
-      `import {`,
-      `  a,`,
-      `  b,`,
-      `} from 'x';`,
-      ``,
-      `const _component = a;`,
-      `export default _component;`,
-    ].join('\n');
-
-    const { imports, body } = splitModule(source);
-
-    expect(imports).toHaveLength(1);
-    expect(imports[0]).toContain('a,');
-    expect(imports[0]).toContain('b,');
-    expect(body).toContain('return _component;');
-  });
-
-  test('handles side-effect imports with no specifiers', () => {
-    const source = [`import 'side-effect';`, `const k = 1;`, `export default k;`].join('\n');
-
-    const { imports, body } = splitModule(source);
-
-    expect(imports).toEqual([`import 'side-effect';`]);
-    expect(body).toContain('return k;');
-  });
-
-  test('handles import with attributes', () => {
-    const source = [
-      `import data from './x.json' with { type: 'json' };`,
-      `export default data;`,
-    ].join('\n');
-
-    const { imports } = splitModule(source);
-
-    expect(imports).toHaveLength(1);
-    expect(imports[0]).toContain('with');
-  });
-
-  test('rewrites only the last export default', () => {
-    const source = [
-      `import X from 'x';`,
-      `// a comment that mentions export default`,
-      `const v = 1;`,
-      `export default v;`,
-    ].join('\n');
-
-    const { body } = splitModule(source);
-
-    expect(body).toContain('return v;');
-    expect(body).not.toContain('return v;\n');
-    // The comment should still be present (not rewritten)
-    expect(body).toContain('export default');
-    // ...but the original statement is gone — only the comment retains the phrase
-    expect(body.match(/return\s+v/g)?.length ?? 0).toBeGreaterThan(0);
-  });
-
-  test('leaves body unchanged when there is no default export', () => {
-    const source = [`import X from 'x';`, `const v = 1;`].join('\n');
-
-    const { body } = splitModule(source);
-
-    expect(body).not.toContain('return');
-    expect(body).toContain('const v = 1;');
-  });
-
-  test('does not hoist import lines out of a template literal', () => {
-    const source = [
-      `import Component from '@glimmer/component';`,
-      'const SAMPLE = `import Component from "@glimmer/component";',
-      `import { tracked } from "@glimmer/tracking";`,
-      '`;',
-      `const _component = SAMPLE;`,
-      `export default _component;`,
-    ].join('\n');
-
-    const { imports, body } = splitModule(source);
-
-    expect(imports).toEqual([`import Component from '@glimmer/component';`]);
-    // The quoted module keeps its own imports
-    expect(body).toContain(`import { tracked } from "@glimmer/tracking";`);
-  });
-
-  test('does not rewrite an export default inside a template literal', () => {
-    const source = [
-      'const SAMPLE = `',
-      `export default class Hello {}`,
-      '`;',
-      `const _component = SAMPLE;`,
-      `export default _component;`,
-    ].join('\n');
-
-    const { body } = splitModule(source);
-
-    expect(body).toContain(`export default class Hello {}`);
-    expect(body).toContain(`return _component;`);
-    expect(body).not.toContain(`return class Hello {}`);
-  });
-});
-
-describe('mergeImports', () => {
-  test('deduplicates exact-match imports', () => {
-    const merged = mergeImports([
-      [`import X from 'x';`, `import { y } from 'y';`],
-      [`import X from 'x';`, `import Z from 'z';`],
-    ]);
-
-    expect(merged).toEqual([`import X from 'x';`, `import { y } from 'y';`, `import Z from 'z';`]);
-  });
-
-  test('does not collapse different specifiers from the same module', () => {
-    const merged = mergeImports([[`import { a } from 'x';`], [`import { b } from 'x';`]]);
-
-    expect(merged).toHaveLength(2);
-  });
-});
-
-describe('wrapAsConst', () => {
-  test('wraps body in an IIFE-returning const', () => {
-    const out = wrapAsConst(`const v = 1;\nreturn v;`, 'Demo1');
-
-    expect(out).toMatch(/^const Demo1 = \(\(\) => \{/);
-    expect(out).toMatch(/\}\)\(\);$/);
-    expect(out).toContain('const v = 1;');
-    expect(out).toContain('return v;');
-  });
-});
+function build(
+  prose: string,
+  demos: Array<{ name: string; placeholderId: string; source: string }>
+) {
+  return buildGmdModule({ babel, prose, demos });
+}
 
 describe('replacePlaceholder', () => {
   test('preserves the placeholder div + class, wraps a component invocation', () => {
@@ -189,108 +44,114 @@ describe('replacePlaceholder', () => {
 });
 
 describe('buildGmdModule', () => {
-  test('build-time form: inlines one demo with build-time template-compiler', () => {
-    const demoSource = [
-      `import Component from '@glimmer/component';`,
-      `import { template } from '@ember/template-compiler';`,
-      `class _Greeting extends Component {`,
-      `  name = 'world';`,
-      `}`,
-      `const _component = template('Hi', { scope: () => ({}) }, _Greeting);`,
-      `export default _component;`,
-    ].join('\n');
-
-    const out = buildGmdModule({
-      prose: `<h1>Hello</h1><div id="repl_1" class="demo"></div>`,
-      demos: [{ name: 'Demo1', placeholderId: 'repl_1', source: demoSource }],
-    });
-
-    // build-time `template` is the default
-    expect(out).toContain(`import { template } from '@ember/template-compiler';`);
-    // Demo's own template-compiler import is deduped against the prose's
-    expect(out.match(/import \{ template \} from '@ember\/template-compiler';/g)?.length).toBe(1);
-    expect(out).toContain(`import Component from '@glimmer/component';`);
-
-    // Demo body wrapped in a named IIFE and referenced from prose. The
-    // prose lives inside a `template(JSON.stringify(...))` call, so double-
-    // quotes in the rewritten div are JSON-escaped.
-    expect(out).toMatch(/const Demo1 = \(\(\) => \{[\s\S]*\}\)\(\);/);
-    expect(out).toContain(`<div class=\\"demo\\"><div data-repl-output><Demo1 /></div></div>`);
-    expect(out).not.toContain(`<div id="repl_1"`);
-    expect(out).not.toContain(`<div id=\\"repl_1\\"`);
-
-    // Scope contains only Demo1
-    expect(out).toMatch(/scope: \(\) => \(\{ Demo1 \}\)/);
-    expect(out).toMatch(/export default _component;/);
-  });
-
-  test('runtime form: imports runtime template-compiler and threads scope via a virtual module specifier', () => {
-    const out = buildGmdModule({
-      prose: `<h1>Hello</h1>`,
-      demos: [],
-      templateModule: '@ember/template-compiler/runtime',
-      scope: {
-        specifier: 'repl-sdk:gmd-scope:42',
-        keys: ['array', 'concat'],
-      },
-    });
-
-    expect(out).toContain(`import { template } from '@ember/template-compiler/runtime';`);
-    expect(out).toContain(`import * as __scope__ from 'repl-sdk:gmd-scope:42';`);
-    // Read through the namespace rather than destructuring: demo imports land
-    // in this same module and would collide with names like `on` or `fn`.
-    expect(out).not.toContain(`const { array, concat } = __scope__;`);
-    expect(out).toMatch(
-      /scope: \(\) => \(\{ array: __scope__\.array, concat: __scope__\.concat \}\)/
-    );
-  });
-
-  test('handles zero demos', () => {
-    const out = buildGmdModule({
-      prose: `<h1>Hello</h1>`,
-      demos: [],
-    });
+  test('emits a build-time template import and an empty scope with no demos', () => {
+    const out = build(`<h1>Hello</h1>`, []);
 
     expect(out).toContain(`import { template } from '@ember/template-compiler';`);
     expect(out).toMatch(/scope: \(\) => \(\{\}\)/);
     expect(out).not.toMatch(/const Demo\d+ = /);
+    expect(out).toContain(`export default _component;`);
   });
 
-  test('emits multiple demos in declaration order, merging shared imports', () => {
-    const make = (n: number) =>
-      [
-        `import Component from '@glimmer/component';`,
-        `const _component = ${n};`,
-        `export default _component;`,
-      ].join('\n');
+  test('inlines a demo, hoists its imports, and references it from the prose', () => {
+    const source = [
+      `import Component from '@glimmer/component';`,
+      `class Greeting extends Component {}`,
+      `export default Greeting;`,
+    ].join('\n');
 
-    const out = buildGmdModule({
-      prose: `<div id="a"></div><div id="b"></div>`,
-      demos: [
-        { name: 'Demo1', placeholderId: 'a', source: make(1) },
-        { name: 'Demo2', placeholderId: 'b', source: make(2) },
-      ],
-    });
+    const out = build(`<h1>Hello</h1><div id="repl_1" class="demo"></div>`, [
+      { name: 'Demo1', placeholderId: 'repl_1', source },
+    ]);
 
-    expect(out.indexOf('const Demo1 ')).toBeLessThan(out.indexOf('const Demo2 '));
+    // the demo's import keeps its original local name
+    expect(out).toContain(`import Component from '@glimmer/component';`);
+    expect(out).toMatch(/const Demo1 = \(\(\) => \{[\s\S]*\}\)\(\);/);
+    expect(out).toContain(`<div class=\\"demo\\"><div data-repl-output><Demo1 /></div></div>`);
+    expect(out).not.toContain(`<div id=\\"repl_1\\"`);
+    expect(out).toMatch(/scope: \(\) => \(\{ Demo1 \}\)/);
+  });
+
+  test('two demos declaring the same top-level name do not collide', () => {
+    const make = (body: string) => [`const value = ${body};`, `export default value;`].join('\n');
+
+    const out = build(`<div id="a"></div><div id="b"></div>`, [
+      { name: 'Demo1', placeholderId: 'a', source: make('1') },
+      { name: 'Demo2', placeholderId: 'b', source: make('2') },
+    ]);
+
     expect(out).toMatch(/scope: \(\) => \(\{ Demo1, Demo2 \}\)/);
-    expect(out.match(/import Component from '@glimmer\/component';/g)?.length).toBe(1);
+    expect(out.indexOf('const Demo1 ')).toBeLessThan(out.indexOf('const Demo2 '));
+    // both demos still produce their own value
+    expect(out).toContain('1');
+    expect(out).toContain('2');
   });
 
-  test('runtime + demos: live-scope keys come before demo names in scope', () => {
-    const make = (n: number) =>
-      [`const _component = ${n};`, `export default _component;`].join('\n');
-
-    const out = buildGmdModule({
-      prose: `<div id="a"></div>`,
-      demos: [{ name: 'Demo1', placeholderId: 'a', source: make(1) }],
-      templateModule: '@ember/template-compiler/runtime',
-      scope: {
-        specifier: 'repl-sdk:gmd-scope:7',
-        keys: ['on'],
+  test('a demo import that collides with another module keeps both bindings', () => {
+    const out = build(`<div id="a"></div><div id="b"></div>`, [
+      {
+        name: 'Demo1',
+        placeholderId: 'a',
+        source: [`import { on } from '@ember/modifier';`, `export default on;`].join('\n'),
       },
-    });
+      {
+        name: 'Demo2',
+        placeholderId: 'b',
+        source: [`import { on } from 'somewhere-else';`, `export default on;`].join('\n'),
+      },
+    ]);
 
-    expect(out).toMatch(/scope: \(\) => \(\{ on: __scope__\.on, Demo1 \}\)/);
+    expect(out).toContain(`from '@ember/modifier';`);
+    expect(out).toContain(`from 'somewhere-else';`);
+    // the second `on` is renamed rather than merged into the first
+    expect(out).toMatch(/on as on\$1|on\$1/);
+  });
+
+  test('the same binding imported by two demos is emitted once', () => {
+    const source = [`import { on } from '@ember/modifier';`, `export default on;`].join('\n');
+
+    const out = build(`<div id="a"></div><div id="b"></div>`, [
+      { name: 'Demo1', placeholderId: 'a', source },
+      { name: 'Demo2', placeholderId: 'b', source },
+    ]);
+
+    expect(out.match(/from '@ember\/modifier';/g)?.length).toBe(1);
+  });
+
+  test('a demo that quotes module syntax in a template literal is left intact', () => {
+    const source = [
+      `import Component from '@glimmer/component';`,
+      'const SAMPLE = `import { tracked } from "@glimmer/tracking";',
+      ``,
+      `export default class Hello extends Component {}`,
+      '`;',
+      `export default SAMPLE;`,
+    ].join('\n');
+
+    const out = build(`<div id="a"></div>`, [{ name: 'Demo1', placeholderId: 'a', source }]);
+
+    // The quoted module keeps its own import and its own export default
+    expect(out).toContain(`import { tracked } from "@glimmer/tracking";`);
+    expect(out).toContain(`export default class Hello extends Component {}`);
+    // ...and only the demo's real import was hoisted, alongside `template`
+    expect(out.match(/^import /gm)?.length).toBe(2);
+  });
+
+  test('a demo without a default export still produces a binding', () => {
+    const out = build(`<div id="a"></div>`, [
+      { name: 'Demo1', placeholderId: 'a', source: `const unused = 1;` },
+    ]);
+
+    expect(out).toMatch(/const Demo1 = \(\(\) => \{/);
+    expect(out).not.toContain('return _demo0_default;');
+  });
+
+  test('named exports in a demo lose the export keyword but keep the declaration', () => {
+    const source = [`export const helper = 1;`, `export default helper;`].join('\n');
+
+    const out = build(`<div id="a"></div>`, [{ name: 'Demo1', placeholderId: 'a', source }]);
+
+    expect(out).not.toMatch(/^\s*export const/m);
+    expect(out).toMatch(/const _demo0_helper = 1;/);
   });
 });

--- a/packages/repl-sdk/src/types.ts
+++ b/packages/repl-sdk/src/types.ts
@@ -39,14 +39,9 @@ export interface PublicMethods {
     options?: {
       flavor?: string;
       fileName?: string;
-      /**
-       * When true, return `{ source: string }` instead of evaluating + rendering.
-       * Most callers should use {@link PublicMethods.compileToSource} instead.
-       */
-      renderToString?: boolean;
       [key: string]: unknown;
     }
-  ) => Promise<{ element: HTMLElement; destroy: () => void } | { source: string }>;
+  ) => Promise<{ element: HTMLElement; destroy: () => void }>;
 
   /**
    * Build-time variant of {@link PublicMethods.compile}: returns the compiled

--- a/packages/repl-sdk/src/types.ts
+++ b/packages/repl-sdk/src/types.ts
@@ -58,6 +58,20 @@ export interface PublicMethods {
     options?: Record<string, unknown>
   ) => Promise<{ source: string }>;
 
+  /**
+   * Register a JS value behind a virtual ES module specifier and return a
+   * cleanup function that unregisters it.
+   *
+   * Compilers reach for this when their emitted source has to talk to a
+   * runtime value that can't be serialized into the source itself — e.g.
+   * gmd's live `scope` object. The emitted module can then
+   * `import * as foo from '<specifier>'` and the Compiler's existing
+   * `manual:` resolver hands the value back.
+   *
+   * @returns A function that unregisters the entry.
+   */
+  provide: (specifier: string, value: unknown) => () => void;
+
   optionsFor: (
     format: string,
     flavor?: string

--- a/packages/repl-sdk/src/types.ts
+++ b/packages/repl-sdk/src/types.ts
@@ -58,20 +58,6 @@ export interface PublicMethods {
     options?: Record<string, unknown>
   ) => Promise<{ source: string }>;
 
-  /**
-   * Register a JS value behind a virtual ES module specifier and return a
-   * cleanup function that unregisters it.
-   *
-   * Compilers reach for this when their emitted source has to talk to a
-   * runtime value that can't be serialized into the source itself — e.g.
-   * gmd's live `scope` object. The emitted module can then
-   * `import * as foo from '<specifier>'` and the Compiler's existing
-   * `manual:` resolver hands the value back.
-   *
-   * @returns A function that unregisters the entry.
-   */
-  provide: (specifier: string, value: unknown) => () => void;
-
   optionsFor: (
     format: string,
     flavor?: string
@@ -114,14 +100,48 @@ type CompileResult =
    */
   | { source: string; [option: string]: unknown };
 
+/**
+ * Per-compile API: everything in {@link PublicMethods}, plus the
+ * {@link CompileAPI.provideScope | provideScope} method whose registrations
+ * are scoped to the compile call (and any render it triggers).
+ *
+ * The Compiler hands a fresh `CompileAPI` to every `compile()` / `render()`
+ * invocation and disposes the registry it tracks after the compile's
+ * destroy fires — individual compilers never have to remember to release
+ * what they registered.
+ */
+export interface CompileAPI extends PublicMethods {
+  /**
+   * Register a JS value behind a Compiler-generated virtual ES module
+   * specifier, and return that specifier. The emitted source for this
+   * compile can then `import * as foo from '<specifier>'` and the
+   * Compiler's existing `manual:` resolver hands the value back.
+   *
+   * The registration is bound to this compile's lifecycle: when the
+   * compile's `destroy()` is called (or the compile throws before
+   * reaching a render), the Compiler releases the entry automatically.
+   * Compilers do not — and should not — track an unregister callback.
+   */
+  provideScope: (value: unknown) => { specifier: string };
+}
+
 export interface Compiler {
   /**
    * Convert a string from "fileExtension" to standard JavaScript.
    * This will be loaded as a module and then passed to the render method.
    *
    * You may return either just a string, or an object with a `compiled` property that is a string -- any additional properties will be passde through to the render function -- which may be useful if there is accompanying CSS.
+   *
+   * The third `api` argument is a per-compile API: same surface as the
+   * factory-time `PublicMethods`, plus `provideScope(value)` whose
+   * registrations are auto-released by the Compiler when the compile's
+   * destroy fires. Existing implementations may ignore it.
    */
-  compile: (text: string, options: Record<string, unknown>) => Promise<CompileResult>;
+  compile: (
+    text: string,
+    options: Record<string, unknown>,
+    api?: CompileAPI
+  ) => Promise<CompileResult>;
 
   /**
    * For the root of a node rendered for this compiler,
@@ -154,7 +174,7 @@ export interface Compiler {
     element: HTMLElement,
     defaultExport: unknown,
     extras: { compiled: string } & Record<string, unknown>,
-    compiler: PublicMethods
+    compiler: CompileAPI
   ) => Promise<void | (() => void)>;
 
   /**

--- a/packages/repl-sdk/src/types.ts
+++ b/packages/repl-sdk/src/types.ts
@@ -39,8 +39,29 @@ export interface PublicMethods {
     options?: {
       flavor?: string;
       fileName?: string;
+      /**
+       * When true, return `{ source: string }` instead of evaluating + rendering.
+       * Most callers should use {@link PublicMethods.compileToSource} instead.
+       */
+      renderToString?: boolean;
+      [key: string]: unknown;
     }
-  ) => Promise<{ element: HTMLElement; destroy: () => void }>;
+  ) => Promise<{ element: HTMLElement; destroy: () => void } | { source: string }>;
+
+  /**
+   * Build-time variant of {@link PublicMethods.compile}: returns the compiled
+   * source as a string rather than evaluating it and rendering to a DOM
+   * element.
+   *
+   * Useful for SSG / pre-rendering pipelines that want to take a live demo's
+   * compiled output and hand it to their own bundler instead of executing it
+   * in the browser.
+   */
+  compileToSource: (
+    format: string,
+    text: string,
+    options?: Record<string, unknown>
+  ) => Promise<{ source: string }>;
 
   optionsFor: (
     format: string,
@@ -76,7 +97,13 @@ type CompileResult =
   | {
       compiled: string;
       [option: string]: unknown;
-    };
+    }
+  /**
+   * Variant returned by compilers when invoked with `renderToString: true` —
+   * the build-time form, where no rendering happens and the caller receives
+   * the compiled JS module source as a string instead of a rendered element.
+   */
+  | { source: string; [option: string]: unknown };
 
 export interface Compiler {
   /**

--- a/packages/repl-sdk/src/types.ts
+++ b/packages/repl-sdk/src/types.ts
@@ -100,48 +100,14 @@ type CompileResult =
    */
   | { source: string; [option: string]: unknown };
 
-/**
- * Per-compile API: everything in {@link PublicMethods}, plus the
- * {@link CompileAPI.provideScope | provideScope} method whose registrations
- * are scoped to the compile call (and any render it triggers).
- *
- * The Compiler hands a fresh `CompileAPI` to every `compile()` / `render()`
- * invocation and disposes the registry it tracks after the compile's
- * destroy fires — individual compilers never have to remember to release
- * what they registered.
- */
-export interface CompileAPI extends PublicMethods {
-  /**
-   * Register a JS value behind a Compiler-generated virtual ES module
-   * specifier, and return that specifier. The emitted source for this
-   * compile can then `import * as foo from '<specifier>'` and the
-   * Compiler's existing `manual:` resolver hands the value back.
-   *
-   * The registration is bound to this compile's lifecycle: when the
-   * compile's `destroy()` is called (or the compile throws before
-   * reaching a render), the Compiler releases the entry automatically.
-   * Compilers do not — and should not — track an unregister callback.
-   */
-  provideScope: (value: unknown) => { specifier: string };
-}
-
 export interface Compiler {
   /**
    * Convert a string from "fileExtension" to standard JavaScript.
    * This will be loaded as a module and then passed to the render method.
    *
    * You may return either just a string, or an object with a `compiled` property that is a string -- any additional properties will be passde through to the render function -- which may be useful if there is accompanying CSS.
-   *
-   * The third `api` argument is a per-compile API: same surface as the
-   * factory-time `PublicMethods`, plus `provideScope(value)` whose
-   * registrations are auto-released by the Compiler when the compile's
-   * destroy fires. Existing implementations may ignore it.
    */
-  compile: (
-    text: string,
-    options: Record<string, unknown>,
-    api?: CompileAPI
-  ) => Promise<CompileResult>;
+  compile: (text: string, options: Record<string, unknown>) => Promise<CompileResult>;
 
   /**
    * For the root of a node rendered for this compiler,
@@ -174,7 +140,7 @@ export interface Compiler {
     element: HTMLElement,
     defaultExport: unknown,
     extras: { compiled: string } & Record<string, unknown>,
-    compiler: CompileAPI
+    compiler: PublicMethods
   ) => Promise<void | (() => void)>;
 
   /**

--- a/packages/repl-sdk/unpublished-development-types/babel-standalone.d.ts
+++ b/packages/repl-sdk/unpublished-development-types/babel-standalone.d.ts
@@ -1,0 +1,18 @@
+/**
+ * `@babel/standalone` ships no types. Only the surface `render-to-string.js`
+ * uses is declared here; the module is otherwise opaque.
+ */
+declare module '@babel/standalone' {
+  export interface BabelStandalone {
+    /** `@babel/types`, `parser`, `generator`, `traverse`, `template` */
+    packages: Record<string, unknown>;
+    transform(
+      code: string,
+      options?: Record<string, unknown>
+    ): { code?: string | null } | null | undefined;
+  }
+
+  const babel: BabelStandalone;
+
+  export default babel;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1374,6 +1374,9 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
     devDependencies:
+      '@babel/standalone':
+        specifier: file:../../babel-standalone.tgz
+        version: file:babel-standalone.tgz
       '@nullvoxpopuli/eslint-configs':
         specifier: ^5.4.0
         version: 5.5.0(753b90aa58c0521fb787daa9416104f1)


### PR DESCRIPTION
## Summary

Adds a build-time variant of `Compiler#compile` to repl-sdk, surfaced as `Compiler#compileToSource(format, text, options)` (and as `options.renderToString: true` on `compile`). Each compiler emits a JavaScript module string instead of evaluating and rendering — useful for SSG / pre-rendering pipelines that want to hand the output to their host app's bundler.

- **gjs** — already returned its babel output as a string; the new path just propagates that without the blob/import dance.
- **hbs** — emits a self-contained `template(<source>, …)` call sourced from `@ember/template-compiler` (build-time variant).
- **gmd** — recursively asks each live code block for its renderToString form, then inlines them into one self-contained module:
  - Imports hoisted + deduped
  - Each demo wrapped in `const Demo<N> = (() => { …; return _component; })();`
  - Trailing `template(prose, { scope: () => ({ …names… }) })` whose prose has the `<div id="placeholderId">` HTML holes rewritten to `<Demo<N> />` Glimmer invocations.

The output is a `.gjs`-shaped JS module that the host app's content-tag + babel pipeline precompiles to wire format. Pre-rendering pipelines can skip the runtime kolay → ember-repl → repl-sdk → parseMarkdown chain entirely.

`ember-repl` exposes the new path via `CompilerService.compileToSource(ext, text, options)`.

## Motivation

`kolay`'s docs pre-render via `vite-ember-ssr` (SSG). Without this, even though the markdown HTML is server-rendered, each `.gjs.md` page still has to do a full runtime compile in the browser before its demos hydrate — leading to a visible flash of unstyled content during rehydration.

With renderToString, `kolay`'s `gjs-md` build plugin can collapse the runtime chain into a single bundler-precompiled module per page.

## Test plan

- [x] Unit tests for the lexical helpers (`splitModule`, `mergeImports`, `wrapAsConst`, `replacePlaceholder`, `buildGmdModule`) covering single-line / multi-line / side-effect / attributed imports, IIFE wrapping, import dedup, placeholder rewriting, scope-list generation, and zero-demo case.
- [x] Existing repl-sdk unit/parse tests still green.
- [x] Type-check: only pre-existing codemirror-lang-* missing-module errors remain.
- [ ] End-to-end verification: wire kolay's `gjs-md` plugin to use this and confirm the docs-app FOUC disappears (follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)