### PR TITLE
Remove on/hash/fn imports

### DIFF
--- a/apps/repl/app/components/copy-menu.gts
+++ b/apps/repl/app/components/copy-menu.gts
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import { on } from '@ember/modifier';
 
 import { copyToClipboard, getSnippetElement } from './copy-utils.ts';
 import Menu from './menu.gts';

--- a/apps/repl/app/components/menu.gts
+++ b/apps/repl/app/components/menu.gts
@@ -1,5 +1,3 @@
-import { hash } from '@ember/helper';
-
 import { focusTrap } from 'ember-focus-trap';
 import { Key } from 'ember-primitives/components/keys';
 import { Menu as HeadlessMenu } from 'ember-primitives/components/menu';
@@ -107,13 +105,13 @@ const Menu: TOC<{
           <div
             class="border"
             style="
-          position: absolute;
-          background: white;
-          width: 8px;
-          height: 8px;
-          transform: rotate(45deg);
-          z-index: 0;
-        "
+        position: absolute;
+        background: white;
+        width: 8px;
+        height: 8px;
+        transform: rotate(45deg);
+        z-index: 0;
+      "
             {{menu.arrow}}
           ></div>
 

--- a/apps/repl/app/components/verify-danger.gts
+++ b/apps/repl/app/components/verify-danger.gts
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 import { cached, tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
 import { service } from '@ember/service';
 
 import { inIframe } from 'ember-primitives/iframe';

--- a/apps/repl/app/templates/edit/demo-select.gts
+++ b/apps/repl/app/templates/edit/demo-select.gts
@@ -1,6 +1,4 @@
 import Component from '@glimmer/component';
-import { fn } from '@ember/helper';
-import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { waitFor } from '@ember/test-waiters';

--- a/apps/repl/app/templates/edit/layout/controls/index.gts
+++ b/apps/repl/app/templates/edit/layout/controls/index.gts
@@ -1,5 +1,4 @@
-import { concat, fn } from '@ember/helper';
-import { on } from '@ember/modifier';
+import { concat } from '@ember/helper';
 import { htmlSafe } from '@ember/template';
 
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';

--- a/apps/repl/app/templates/edit/layout/index.gts
+++ b/apps/repl/app/templates/edit/layout/index.gts
@@ -1,5 +1,4 @@
 import { assert } from '@ember/debug';
-import { fn } from '@ember/helper';
 
 import { modifier } from 'ember-modifier';
 
@@ -72,10 +71,10 @@ export const Layout: TOC<{
     {{#let (containerDirection state) as |horizontallySplit|}}
       <Orientation as |isVertical|>
         {{! Normally we don't do effects in app code,
-            because we can derive all state.
+          because we can derive all state.
 
-            But XState is an *evented* system, so we have to send events.
-        }}
+          But XState is an *evented* system, so we have to send events.
+      }}
         {{effect (fn state.send (updateOrientation isVertical))}}
 
         <div
@@ -98,10 +97,10 @@ export const Layout: TOC<{
           </EditorContainer>
 
           {{!
-            Unfortunately, even if we were to use native container queries,
-            we wouldn't be able to conditionally render stuff as
-            native container queries are CSS only.
-          }}
+          Unfortunately, even if we were to use native container queries,
+          we wouldn't be able to conditionally render stuff as
+          native container queries are CSS only.
+        }}
           {{#if (isResizable state)}}
             <ResizeHandle @direction={{resizeDirection horizontallySplit}} />
           {{/if}}

--- a/apps/repl/app/templates/edit/layout/orientation.gts
+++ b/apps/repl/app/templates/edit/layout/orientation.gts
@@ -1,5 +1,3 @@
-import { hash } from '@ember/helper';
-
 import { aspectRatio, ContainerQuery } from 'ember-container-query';
 
 import constrainVertically from 'limber/modifiers/constrain-vertically';

--- a/apps/repl/app/templates/edit/layout/status.gts
+++ b/apps/repl/app/templates/edit/layout/status.gts
@@ -1,6 +1,4 @@
 import Component from '@glimmer/component';
-import { fn } from '@ember/helper';
-import { on } from '@ember/modifier';
 import { service } from '@ember/service';
 
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';


### PR DESCRIPTION
Removed 5 'on' and 2 'hash' and 4 'fn' imports across 8 files.

FYI, When I ran `pnpm lint:prettier:fix`, it made some whitespace changes. I guess this means lint and lint fix are inconsistent.  I can change it back if you'd like.
