### PR TITLE
Raise the resize handle above the panels' positioned content

### DIFF
--- a/apps/repl/app/templates/edit/layout/styles.css
+++ b/apps/repl/app/templates/edit/layout/styles.css
@@ -1,3 +1,13 @@
+.limber__layout {
+  /**
+   * Above the panels' positioned content (e.g. the editor's controls),
+   * so the handle stays visible and grabbable along the shared edge.
+   */
+  & .ember-primitives__resizable__handle {
+    z-index: 1;
+  }
+}
+
 /**
  * Minimize / maximize are CSS overrides on top of <Resizable>'s
  * inline flex sizing (hence the !important) -- the split sizes are


### PR DESCRIPTION
Follow-up to #2179: the panels contain positioned content (the editor's controls sit at `z-index: 1`), which could paint over — and steal pointer events from — the 0.5rem handle along the shared edge. The handle now gets `z-index: 1` in `layout/styles.css` (it is already `position: relative` from ember-primitives' stylesheet).

Verified via hit-testing: `document.elementFromPoint` at the handle's midpoint resolves to the handle. All 61 repl tests pass, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)