### PR TITLE
Pin all workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: wyvox/action@v2
+    - uses: wyvox/action@d463e4fd48f0863f09cadf66203c1780b694620c # v2.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - run: pnpm turbo build --force
@@ -49,7 +49,7 @@ jobs:
     needs: [install_dependencies]
 
     steps:
-    - uses: wyvox/action@v2
+    - uses: wyvox/action@d463e4fd48f0863f09cadf66203c1780b694620c # v2.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - run: pnpm turbo build:test
@@ -61,14 +61,14 @@ jobs:
     needs: [install_dependencies]
 
     steps:
-    - uses: wyvox/action@v2
+    - uses: wyvox/action@d463e4fd48f0863f09cadf66203c1780b694620c # v2.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - run: pnpm turbo build:prod
     - run: ls -la ./apps/repl/dist
     - run: ls -la ./apps/tutorial/dist
     # Used for faster deploy so we don't need to checkout the repo
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: deploy-prep-dist
         if-no-files-found: error
@@ -88,7 +88,7 @@ jobs:
     needs: [install_dependencies]
 
     steps:
-      - uses: wyvox/action@v2
+      - uses: wyvox/action@d463e4fd48f0863f09cadf66203c1780b694620c # v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm build
@@ -111,7 +111,7 @@ jobs:
     needs: [build_tests]
 
     steps:
-      - uses: wyvox/action@v2
+      - uses: wyvox/action@d463e4fd48f0863f09cadf66203c1780b694620c # v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Environment Info
@@ -173,7 +173,7 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         name: deploy-prep-dist
       - name: Publish ${{ matrix.app.name }}
         working-directory: ./deploy-prep-dist/${{ matrix.app.path }}

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -12,6 +12,6 @@ jobs:
 
     steps:
       - name: Contribute List
-        uses: akhilmhdh/contributors-readme-action@v2.3.11
+        uses: akhilmhdh/contributors-readme-action@83ea0b4f1ac928fbfe88b9e8460a932a528eb79f # v2.3.11
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -135,7 +135,7 @@ jobs:
         - { path: "./repl/dist", cloudflareName: "limber-glimdown", name: "limber" }
     steps:
       - name: Download build artifact from the CI run
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: deploy-prep-dist
           path: ./deploy-prep-dist
@@ -164,7 +164,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: marocchino/sticky-pull-request-comment@v3
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: preview-urls
           number: ${{ needs.determinePR.outputs.number }}

--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       should-prepare: ${{ steps.should-prepare.outputs.should-prepare }}
     steps:
-      - uses: release-plan/actions/should-prepare-release@v1
+      - uses: release-plan/actions/should-prepare-release@f92e35b6889c1128d3c45875aada8097d5ed802a # v1.0.2
         with:
           ref: 'main'
         id: should-prepare
@@ -43,7 +43,7 @@ jobs:
       pull-requests: write
     if: needs.should-run-release-plan-prepare.outputs.should-prepare == 'true'
     steps:
-      - uses: release-plan/actions/prepare@v1
+      - uses: release-plan/actions/prepare@f92e35b6889c1128d3c45875aada8097d5ed802a # v1.0.2
         name: Run release-plan prepare
         with:
           ref: 'main'
@@ -51,7 +51,7 @@ jobs:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
         id: explanation
 
-      - uses: peter-evans/create-pull-request@v8
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         name: Create Prepare Release PR
         with:
           commit-message: "Prepare Release ${{ steps.explanation.outputs.new-version}} using 'release-plan'"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       attestations: write
 
     steps:
-      - uses: wyvox/action@v2
+      - uses: wyvox/action@d463e4fd48f0863f09cadf66203c1780b694620c # v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/test-ember-source.yml
+++ b/.github/workflows/test-ember-source.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Resolve branch name
         id: resolve
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         # Read the input from env, not string-interpolated into the script:
         # a backtick or ${...} in the value would otherwise break out of the
         # template literal and run as JS.
@@ -103,12 +103,12 @@ jobs:
       contents: read
     steps:
       # No limber checkout here, so we specify the pnpm version explicitly.
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 10.33.4
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: "24"
 
@@ -152,7 +152,7 @@ jobs:
           echo "tarball-path=$tarball" >> "$GITHUB_OUTPUT"
 
       - name: Upload tarball artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ember-source-tarball
           path: ${{ steps.tarball.outputs.tarball-path }}
@@ -173,22 +173,22 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           # create-pull-request pushes with its own token; don't leave the
           # workflow GITHUB_TOKEN in .git/config.
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: "24"
 
       - name: Download tarball artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ember-source-tarball
           path: /tmp/ember-tarball
@@ -210,7 +210,7 @@ jobs:
           echo "tarball-name=$tarball_name" >> "$GITHUB_OUTPUT"
 
       - name: Configure pnpm override and ember-source reference
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           TARBALL_NAME: ${{ steps.tarball.outputs.tarball-name }}
         with:
@@ -277,7 +277,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GH_TOKEN_EMBER_SOURCE_TESTING_PR }}
           commit-message: "Add ember-source tarball from ${{ needs.resolve.outputs.branch }}"

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -2,10 +2,9 @@
 rules:
   unpinned-uses:
     config:
-      # Require every `uses:` to name at least a tag/branch ref (catches a bare
-      # `@main` or missing ref). We do NOT require full commit-hash pins yet:
-      # the repo pins to tags throughout, and moving to hash pins is a larger,
-      # dependabot-maintained change best done on its own. Tightening the
-      # third-party entries to `hash-pin` here later is the recommended next step.
+      # Every `uses:` must be pinned to a full commit SHA. Tags are mutable --
+      # a hash pin is the only reference an attacker who compromises an action's
+      # repo can't move. Renovate bumps these SHAs (and the `# vX.Y.Z` comment)
+      # automatically, so pinning doesn't freeze us on stale versions.
       policies:
-        "*": ref-pin
+        "*": hash-pin


### PR DESCRIPTION
Pins every workflow action to a full commit SHA and flips zizmor's `unpinned-uses` policy to `hash-pin` so CI enforces it going forward.

> [!NOTE]
> **Stacked on #2188** (which is stacked on #2187). Merge those first; this PR's diff then collapses to just the pin changes below. It builds on #2188 because it tightens the `unpinned-uses` policy that PR introduced.

## Why

A tag like `@v3` is a mutable pointer. If an action's repo (or a maintainer's account) is compromised, an attacker can re-point the tag at malicious code and every workflow using it runs that code with whatever token/secrets the job holds — the [tj-actions/changed-files compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-with-commit-fdfc60f) (March 2025) is exactly this. A commit SHA is immutable, so it's the one reference the attacker can't move.

## What changed

- Every active `uses:` across all seven workflows is pinned to a full 40-char commit SHA, each with a trailing `# vX.Y.Z` comment for readability.
- `.github/zizmor.yml`: `unpinned-uses` policy `ref-pin` → `hash-pin`. CI now fails if any future `uses:` lands without a SHA.

## Pinning policy

Each action was pinned to the **latest SHA of the line it currently references** — moving major tags (`@v6`, `@v2`, …) resolve to the newest SHA of that major; already-exact tags (`akhilmhdh/contributors-readme-action@v2.3.11`, `zizmorcore/zizmor-action@v0.5.0`) keep their version. **No intentional version upgrades** — this is a pin, not a bump. `actions/checkout` is now one shared SHA (`v6.1.0`) everywhere.

## Staying current

Renovate (`renovate.json5`) already manages this repo and updates SHA-pinned actions that carry a version comment — it bumps the SHA and the `# vX.Y.Z` together — so pinning doesn't strand us on stale versions. No new config needed.

## Verified

`zizmor .github/` → **No findings** under the stricter `hash-pin` policy. `actionlint` clean on all seven workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
