### PR TITLE
Upgrade xstate to 5.32.5; drop unused @xstate/inspect

### DIFF
--- a/apps/repl/package.json
+++ b/apps/repl/package.json
@@ -154,7 +154,6 @@
     "@nullvoxpopuli/limber-shared": "workspace:*",
     "@nullvoxpopuli/limber-styles": "workspace:*",
     "@shikijs/rehype": "^3.21.0",
-    "@xstate/inspect": "^0.8.0",
     "browserslist": "^4.28.1",
     "dompurify": "^3.3.1",
     "ember-container-query": "7.0.3",
@@ -186,6 +185,6 @@
     "unified": "^11.0.5",
     "unist-util-flatmap": "^1.0.0",
     "unist-util-visit": "^5.0.0",
-    "xstate": "5.30.0"
+    "xstate": "5.32.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,9 +111,6 @@ importers:
       '@shikijs/rehype':
         specifier: ^3.21.0
         version: 3.23.0
-      '@xstate/inspect':
-        specifier: ^0.8.0
-        version: 0.8.0(48eeb908343dc5b4be25bf5290290db9)
       browserslist:
         specifier: ^4.28.1
         version: 4.28.2
@@ -146,7 +143,7 @@ importers:
         version: 7.1.0(5417512ae382abcafe5679ee7b1ac481)
       ember-statechart-component:
         specifier: 7.1.0
-        version: 7.1.0(fa5fea218477f7f554b97019bbf2d346)
+        version: 7.1.0(037258e6c3e5475c885d8b51dfc92022)
       html-to-image:
         specifier: ^1.11.13
         version: 1.11.13
@@ -208,8 +205,8 @@ importers:
         specifier: ^5.0.0
         version: 5.1.0
       xstate:
-        specifier: 5.30.0
-        version: 5.30.0
+        specifier: 5.32.5
+        version: 5.32.5
     devDependencies:
       '@babel/core':
         specifier: ^7.28.5
@@ -5206,16 +5203,6 @@ packages:
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
 
-  '@xstate/inspect@0.8.0':
-    resolution: {integrity: sha512-wSkFeOnp+7dhn+zTThO0M4D2FEqZN9lGIWowJu5JLa2ojjtlzRwK8SkjcHZ4rLX8VnMev7kGjgQLrGs8kxy+hw==}
-    peerDependencies:
-      '@types/ws': ^8.0.0
-      ws: ^8.0.0
-      xstate: ^4.37.0
-    peerDependenciesMeta:
-      '@types/ws':
-        optional: true
-
   '@zip.js/zip.js@2.8.16':
     resolution: {integrity: sha512-kCjaXh50GCf9afcof6ekjXPKR//rBVIxNHJLSUaM3VAET2F0+hymgrK1GpInRIIFUpt+wsnUfgx2+bbrmc+7Tw==}
     engines: {bun: '>=0.7.0', deno: '>=1.0.0', node: '>=18.0.0'}
@@ -7368,9 +7355,6 @@ packages:
 
   fast-ordered-set@1.0.3:
     resolution: {integrity: sha512-MxBW4URybFszOx1YlACEoK52P6lE3xiFcPaGCUZ7QQOZ6uJXKo++Se8wa31SjcZ+NC/fdAWX7UtKEfaGgHS2Vg==}
-
-  fast-safe-stringify@2.1.1:
-    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-sourcemap-concat@2.1.1:
     resolution: {integrity: sha512-7h9/x25c6AQwdU3mA8MZDUMR3UCy50f237egBrBkuwjnUZSmfu4ptCf91PZSKzON2Uh5VvIHozYKWcPPgcjxIw==}
@@ -11329,8 +11313,8 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
-  xstate@5.30.0:
-    resolution: {integrity: sha512-mIzIuMjtYVkqXq9dUzYQoag7b/dF1CBS/yhliuPLfR0FwKPC18HiUivb/crcqY2gknhR8gJEhnppLg6ubQ0gGw==}
+  xstate@5.32.5:
+    resolution: {integrity: sha512-ULazi1oe6wGrXl0Frb6otSlkm5HLifbbVTkMk5kkSKqz4TkxJaVpnl6jOJwKeid3ORPxYyZQgNLUSYX9q65SIA==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -15022,14 +15006,6 @@ snapshots:
 
   '@xmldom/xmldom@0.9.10': {}
 
-  '@xstate/inspect@0.8.0(48eeb908343dc5b4be25bf5290290db9)':
-    dependencies:
-      fast-safe-stringify: 2.1.1
-      ws: 8.19.0
-      xstate: 5.30.0
-    optionalDependencies:
-      '@types/ws': 8.18.1
-
   '@zip.js/zip.js@2.8.16': {}
 
   abort-controller@3.0.0:
@@ -17121,14 +17097,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-statechart-component@7.1.0(fa5fea218477f7f554b97019bbf2d346):
+  ember-statechart-component@7.1.0(037258e6c3e5475c885d8b51dfc92022):
     dependencies:
       '@ember/test-waiters': 4.1.1(c8332dc3f90c0e60eb130a3a85f980b9)
       '@embroider/addon-shim': 1.10.2
       '@glimmer/component': 2.1.1
       '@glint/template': 1.7.7
       decorator-transforms: 2.3.1(@babel/core@7.29.0)
-      xstate: 5.30.0
+      xstate: 5.32.5
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -17684,8 +17660,6 @@ snapshots:
   fast-ordered-set@1.0.3:
     dependencies:
       blank-object: 1.0.2
-
-  fast-safe-stringify@2.1.1: {}
 
   fast-sourcemap-concat@2.1.1:
     dependencies:
@@ -22444,7 +22418,7 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
-  xstate@5.30.0: {}
+  xstate@5.32.5: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
Upgrades `xstate` in `apps/repl` from 5.30.0 to 5.32.5 (latest).

- `ember-statechart-component`'s peer range (`^5.18.0`) already covers it — no other changes needed.
- Removes `@xstate/inspect` (^0.8.0): it has no imports anywhere in the repo (it's also the v4-era inspector; v5 uses `@statelyai/inspect`).

Verified: `ember-tsc --noEmit` clean; full repl test suite green (61 tests: 54 pass, 7 skip — same as main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)