### PR TITLE
Bubble content-tag (SWC) parse error details up to the UI's error bubble

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
       "object.values": "npm:@nolyfill/object.values@^1",
       "reactiveweb": "1.9.1",
       "@codemirror/view": "6.39.12",
-      "ember-repl": "^8.0.0",
+      "kolay>ember-repl": "^8.0.0",
       "side-channel": "npm:@nolyfill/side-channel@^1",
       "string.prototype.matchall": "npm:@nolyfill/string.prototype.matchall@^1",
       "string.prototype.trimend": "npm:@nolyfill/string.prototype.trimend@^1"

--- a/packages/ember-repl/src/compile/state.ts
+++ b/packages/ember-repl/src/compile/state.ts
@@ -1,5 +1,7 @@
 import { tracked } from '@glimmer/tracking';
 
+import { errorMessage } from 'repl-sdk';
+
 import type { ComponentLike } from '@glint/template';
 
 export const RESOLVE = Symbol('CompileState::resolve');
@@ -42,7 +44,7 @@ export class CompileState implements State {
   }
 
   get reason() {
-    return this.error?.message;
+    return this.error ? errorMessage(this.error) : undefined;
   }
 
   get isWaiting() {

--- a/packages/ember-repl/tests/rendering/compile-gjs-test.gts
+++ b/packages/ember-repl/tests/rendering/compile-gjs-test.gts
@@ -63,6 +63,56 @@ module('Rendering | compile()', function (hooks) {
       assert.dom('button').hasText('Click');
     });
 
+    test('parse errors are not swallowed', async function (assert) {
+      const compiler = getCompiler(this);
+
+      /**
+       * The `= ;` is a syntax error, which content-tag (SWC) reports
+       * with a bare "Parse Error at <file>:<line>:<column>" message —
+       * the explanation and code frame are on the error's `source_code` property.
+       */
+      const snippet = stripIndent`
+        const isBroken = ;
+
+        <template>{{isBroken}}</template>
+      `;
+
+      let reported: string | undefined;
+
+      const state = compile(compiler, snippet, {
+        format: 'gjs',
+        onError: (error) => (reported = error),
+      });
+
+      await state.promise.catch(() => {
+        /* the rejection is the point of this test */
+      });
+
+      assert.ok(state.error, 'the compile state has an error');
+
+      for (const [name, message] of [
+        ['state.reason', state.reason],
+        ['onError', reported],
+        [
+          'the UI error bubble (via compiler.lastError)',
+          compiler.lastError?.message,
+        ],
+      ] as const) {
+        assert.true(
+          message?.includes('Parse Error at'),
+          `${name} says where the parse error is`
+        );
+        assert.true(
+          message?.includes('Expression expected'),
+          `${name} explains what the parse error is`
+        );
+        assert.true(
+          message?.includes('const isBroken = ;'),
+          `${name} includes the code frame`
+        );
+      }
+    });
+
     test('it works', async function (assert) {
       const compile = async () => {
         const template = `

--- a/packages/ember-repl/tests/rendering/compile-gjs-test.gts
+++ b/packages/ember-repl/tests/rendering/compile-gjs-test.gts
@@ -1,5 +1,11 @@
 import { assert as debugAssert } from '@ember/debug';
-import { click, render, settled, setupOnerror } from '@ember/test-helpers';
+import {
+  click,
+  render,
+  settled,
+  setupOnerror,
+  waitUntil,
+} from '@ember/test-helpers';
 import QUnit, { module, skip, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 
@@ -17,6 +23,10 @@ import type { ComponentLike } from '@glint/template';
 function unexpectedErrorHandler(error: unknown) {
   console.error(error);
   QUnit.assert.notOk(`CHECK CONSOLE: did not expect error: ${String(error)}`);
+}
+
+function errorMessagesIn(compiler: ReturnType<typeof getCompiler>) {
+  return compiler.messages.filter((message) => message.type === 'error');
 }
 
 module('Rendering | compile()', function (hooks) {
@@ -77,39 +87,60 @@ module('Rendering | compile()', function (hooks) {
         <template>{{isBroken}}</template>
       `;
 
-      let reported: string | undefined;
+      /**
+       * Mirroring how apps use compile(): nobody awaits state.promise,
+       * so its rejection also fires the browser's unhandledrejection event,
+       * whose announcement is the *last* error message -- the one the UI's
+       * error bubble ends up showing.
+       *
+       * QUnit fails tests on unhandled rejections; that unhandled rejection
+       * is the point of this test, so silence QUnit's handler for its duration.
+       */
+      const onUncaughtException = QUnit.onUncaughtException;
 
-      const state = compile(compiler, snippet, {
-        format: 'gjs',
-        onError: (error) => (reported = error),
-      });
+      QUnit.onUncaughtException = () => {};
 
-      await state.promise.catch(() => {
-        /* the rejection is the point of this test */
-      });
+      try {
+        let reported: string | undefined;
 
-      assert.ok(state.error, 'the compile state has an error');
+        const state = compile(compiler, snippet, {
+          format: 'gjs',
+          onError: (error) => (reported = error),
+        });
 
-      for (const [name, message] of [
-        ['state.reason', state.reason],
-        ['onError', reported],
-        [
-          'the UI error bubble (via compiler.lastError)',
-          compiler.lastError?.message,
-        ],
-      ] as const) {
-        assert.true(
-          message?.includes('Parse Error at'),
-          `${name} says where the parse error is`
-        );
-        assert.true(
-          message?.includes('Expression expected'),
-          `${name} explains what the parse error is`
-        );
-        assert.true(
-          message?.includes('const isBroken = ;'),
-          `${name} includes the code frame`
-        );
+        await waitUntil(() => state.error, { timeout: 10_000 });
+
+        // Wait for the unhandledrejection announcement
+        // (the compile() announcement is first, this one is second)
+        await waitUntil(() => errorMessagesIn(compiler).length >= 2, {
+          timeout: 10_000,
+        });
+
+        assert.ok(state.error, 'the compile state has an error');
+
+        for (const [name, message] of [
+          ['state.reason', state.reason],
+          ['onError', reported],
+          [
+            'the UI error bubble (via compiler.lastError)',
+            compiler.lastError?.message,
+          ],
+        ] as const) {
+          assert.true(
+            message?.includes('Parse Error at'),
+            `${name} says where the parse error is`
+          );
+          assert.true(
+            message?.includes('Expression expected'),
+            `${name} explains what the parse error is`
+          );
+          assert.true(
+            message?.includes('const isBroken = ;'),
+            `${name} includes the code frame`
+          );
+        }
+      } finally {
+        QUnit.onUncaughtException = onUncaughtException;
       }
     });
 

--- a/packages/repl-sdk/src/compilers.ember.onUnhandled.test.ts
+++ b/packages/repl-sdk/src/compilers.ember.onUnhandled.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { gjs } from './compilers/ember.js';
+
+function handleUnhandled(reason: unknown) {
+  let handled: string | undefined;
+
+  gjs.onUnhandled?.({ reason } as PromiseRejectionEvent, (message) => (handled = message));
+
+  return handled;
+}
+
+/**
+ * In apps, nothing awaits the compile state's promise, so compile errors
+ * also arrive via unhandledrejection — and this handler's announcement is
+ * the last one, i.e. the one the UI's error bubble shows.
+ */
+describe('gjs onUnhandled', () => {
+  it('ignores reasons without a message', () => {
+    expect(handleUnhandled(undefined)).toBe(undefined);
+    expect(handleUnhandled('boom')).toBe(undefined);
+  });
+
+  it('uses the message of a normal Error', () => {
+    expect(handleUnhandled(new Error('boom'))).toBe('boom');
+  });
+
+  it('includes the source_code of an SWC-style error (as thrown by content-tag)', () => {
+    const swcError = Object.assign(new Error('Parse Error at dynamic-repl.js:3:16: 3:33'), {
+      source_code:
+        "  × Expected 'from', got 'string literal'\n" +
+        '   ╭─[dynamic-repl.js:3:1]\n' +
+        " 2 │ import { tracked } from '@glimmer/tracking';\n" +
+        " 3 │ import { on }  '@ember/modifier';\n" +
+        '   ·                ─────────────────\n' +
+        '   ╰────',
+    });
+
+    expect(handleUnhandled(swcError)).toMatchInlineSnapshot(`
+      "Parse Error at dynamic-repl.js:3:16: 3:33
+
+        × Expected 'from', got 'string literal'
+         ╭─[dynamic-repl.js:3:1]
+       2 │ import { tracked } from '@glimmer/tracking';
+       3 │ import { on }  '@ember/modifier';
+         ·                ─────────────────
+         ╰────"
+    `);
+  });
+
+  it('points at the console for backtracking-rerender asserts', () => {
+    const message = handleUnhandled(
+      new Error('Assertion Failed: ...\n\nStack trace for the update:\n...')
+    );
+
+    expect(message).toContain('(see console)');
+  });
+});

--- a/packages/repl-sdk/src/compilers/ember.js
+++ b/packages/repl-sdk/src/compilers/ember.js
@@ -2,6 +2,8 @@
  * @typedef {import('../types.ts').CompilerConfig} CompilerConfig
  */
 
+import { errorMessage } from '../utils.js';
+
 /**
  * Other `@ember` (and `@glimmer`) packages are bundled in ember-source,
  * and typecilaly use a build plugin to resolve from `@ember/*` imports.
@@ -91,7 +93,7 @@ function resolve(id) {
 function onUnhandled(e, handle) {
   if (!e.reason?.message) return;
 
-  let reason = e.reason.message;
+  let reason = errorMessage(e.reason);
 
   if (reason.includes('Stack trace for the update:')) {
     reason += ' (see console)';

--- a/packages/repl-sdk/src/index.d.ts
+++ b/packages/repl-sdk/src/index.d.ts
@@ -3,6 +3,13 @@ import type { EditorView } from 'codemirror';
 
 export type { ErrorMessage, InfoMessage, Message, Options } from './types.ts';
 
+/**
+ * Builds the most useful human-readable message from a thrown error,
+ * including the explanation and code-frame from SWC / content-tag
+ * parse errors (which hide those on a non-standard `source_code` property).
+ */
+export function errorMessage(error: unknown): string;
+
 export const defaultFormats: keyof Options['formats'];
 export const defaults: Options;
 

--- a/packages/repl-sdk/src/index.js
+++ b/packages/repl-sdk/src/index.js
@@ -10,9 +10,11 @@ import { compilers } from './compilers.js';
 import { STABLE_REFERENCE } from './es-module-shim.js';
 import { getTarRequestId } from './request.js';
 import { getFromTarball } from './tar.js';
-import { assert, nextId, prefix_tgz, tgzPrefix, unzippedPrefix } from './utils.js';
+import { assert, errorMessage, nextId, prefix_tgz, tgzPrefix, unzippedPrefix } from './utils.js';
 
 assert(`There is no document. repl-sdk is meant to be ran in a browser`, globalThis.document);
+
+export { errorMessage } from './utils.js';
 
 export const defaultFormats = Object.keys(compilers);
 
@@ -98,7 +100,7 @@ export class Compiler {
 
     if (handled) return;
 
-    this.#announce('error', e.reason);
+    this.#announce('error', errorMessage(e.reason));
   };
 
   /**
@@ -355,9 +357,7 @@ export class Compiler {
       return await this.#compile(format, text, options);
     } catch (e) {
       // for on.log usage
-      const message = e instanceof Error ? e.message : e;
-
-      this.#announce('error', String(message));
+      this.#announce('error', errorMessage(e));
 
       // Don't hide errors!
       this.#error(e);

--- a/packages/repl-sdk/src/utils.errorMessage.test.ts
+++ b/packages/repl-sdk/src/utils.errorMessage.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { errorMessage } from './utils.js';
+
+describe('errorMessage', () => {
+  it('handles non-object throwables', () => {
+    expect(errorMessage('boom')).toBe('boom');
+    expect(errorMessage(undefined)).toBe('undefined');
+    expect(errorMessage(null)).toBe('null');
+    expect(errorMessage(2)).toBe('2');
+  });
+
+  it('uses the message of a normal Error', () => {
+    expect(errorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('falls back to String() for objects without message or source_code', () => {
+    expect(errorMessage({})).toBe('[object Object]');
+  });
+
+  it('includes the source_code of an SWC-style error (as thrown by content-tag)', () => {
+    /**
+     * Real shape from content-tag's `Preprocessor#process`:
+     * an Error with extra own properties: source_code, source_code_color
+     */
+    const swcError = Object.assign(new Error('Parse Error at dynamic-repl.js:1:9: 1:10'), {
+      source_code:
+        '  × Expression expected\n' +
+        '   ╭─[dynamic-repl.js:1:1]\n' +
+        ' 1 │ let y = ;\n' +
+        '   ·         ─\n' +
+        '   ╰────',
+    });
+
+    expect(errorMessage(swcError)).toMatchInlineSnapshot(`
+      "Parse Error at dynamic-repl.js:1:9: 1:10
+
+        × Expression expected
+         ╭─[dynamic-repl.js:1:1]
+       1 │ let y = ;
+         ·         ─
+         ╰────"
+    `);
+  });
+});

--- a/packages/repl-sdk/src/utils.js
+++ b/packages/repl-sdk/src/utils.js
@@ -39,3 +39,36 @@ export function prefix_tgz(url) {
 export function isRecord(x) {
   return typeof x === 'object' && x !== null && !Array.isArray(x);
 }
+
+/**
+ * Builds the most useful human-readable message from a thrown error.
+ *
+ * SWC (via content-tag) throws Errors whose `message` is only
+ * "Parse Error at <file>:<line>:<column>" — the explanation of what's
+ * wrong and the code-frame live on a non-standard `source_code` property
+ * (and `stack` is nothing but wasm frames).
+ *
+ * @param {unknown} error
+ * @returns {string}
+ */
+export function errorMessage(error) {
+  if (!isRecord(error)) {
+    return String(error);
+  }
+
+  const parts = [];
+
+  if ('message' in error && error.message) {
+    parts.push(String(error.message));
+  }
+
+  if ('source_code' in error && error.source_code) {
+    parts.push(String(error.source_code));
+  }
+
+  if (parts.length === 0) {
+    return String(error);
+  }
+
+  return parts.join('\n\n');
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ overrides:
   object.values: npm:@nolyfill/object.values@^1
   reactiveweb: 1.9.1
   '@codemirror/view': 6.39.12
-  ember-repl: ^8.0.0
+  kolay>ember-repl: ^8.0.0
   side-channel: npm:@nolyfill/side-channel@^1
   string.prototype.matchall: npm:@nolyfill/string.prototype.matchall@^1
   string.prototype.trimend: npm:@nolyfill/string.prototype.trimend@^1
@@ -136,8 +136,8 @@ importers:
         specifier: ^0.61.1
         version: 0.61.1(a64917a33376b7be2998bd4d1c9f349f)
       ember-repl:
-        specifier: ^8.0.0
-        version: 8.0.2(97a2ca31a8e4cf9a385bac208eb0c5f1)
+        specifier: workspace:*
+        version: link:../../packages/ember-repl
       ember-resources:
         specifier: ^7.1.0
         version: 7.1.0(5417512ae382abcafe5679ee7b1ac481)
@@ -464,8 +464,8 @@ importers:
         specifier: ^0.61.1
         version: 0.61.1(a64917a33376b7be2998bd4d1c9f349f)
       ember-repl:
-        specifier: ^8.0.0
-        version: 8.0.2(97a2ca31a8e4cf9a385bac208eb0c5f1)
+        specifier: latest
+        version: 8.1.0(97a2ca31a8e4cf9a385bac208eb0c5f1)
       ember-resources:
         specifier: ^7.1.0
         version: 7.1.0(5417512ae382abcafe5679ee7b1ac481)
@@ -1372,7 +1372,7 @@ importers:
     devDependencies:
       '@nullvoxpopuli/eslint-configs':
         specifier: ^5.4.0
-        version: 5.5.0(80764094b1320bd5efa87f121ad32aaf)
+        version: 5.5.0(753b90aa58c0521fb787daa9416104f1)
       '@tsconfig/ember':
         specifier: ^3.0.7
         version: 3.0.12
@@ -1390,7 +1390,7 @@ importers:
         version: 1.8.2
       decorator-transforms:
         specifier: 2.3.1
-        version: 2.3.1(@babel/core@7.29.7)
+        version: 2.3.1(@babel/core@7.29.0)
       eslint:
         specifier: ^9.39.1
         version: 9.39.2(jiti@2.6.1)
@@ -1424,13 +1424,13 @@ importers:
     devDependencies:
       '@babel/plugin-proposal-decorators':
         specifier: ^7.28.0
-        version: 7.29.7(@babel/core@7.29.7)
+        version: 7.29.7(@babel/core@7.29.0)
       '@babel/standalone':
         specifier: file:../../../babel-standalone.tgz
         version: file:babel-standalone.tgz
       '@nullvoxpopuli/eslint-configs':
         specifier: ^5.4.0
-        version: 5.5.0(066eb5d36fe40fce3e130e3794ecd49a)
+        version: 5.5.0(753b90aa58c0521fb787daa9416104f1)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -2253,7 +2253,7 @@ importers:
     devDependencies:
       '@nullvoxpopuli/eslint-configs':
         specifier: ^5.4.0
-        version: 5.5.0(80764094b1320bd5efa87f121ad32aaf)
+        version: 5.5.0(753b90aa58c0521fb787daa9416104f1)
       eslint:
         specifier: ^9.39.1
         version: 9.39.2(jiti@2.6.1)
@@ -2320,10 +2320,6 @@ packages:
 
   '@babel/core@7.29.0':
     resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/core@7.29.7':
-    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/eslint-parser@7.28.6':
@@ -2422,10 +2418,6 @@ packages:
 
   '@babel/helpers@7.28.6':
     resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helpers@7.29.7':
-    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.7':
@@ -3386,12 +3378,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@eslint-community/eslint-utils@4.10.1':
-    resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3406,10 +3392,6 @@ packages:
     resolution: {integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/config-array@0.21.2':
-    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@eslint/config-helpers@0.4.2':
     resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3422,16 +3404,8 @@ packages:
     resolution: {integrity: sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/eslintrc@3.3.6':
-    resolution: {integrity: sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@eslint/js@9.39.2':
     resolution: {integrity: sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/js@9.39.5':
-    resolution: {integrity: sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.7':
@@ -3541,20 +3515,8 @@ packages:
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
 
-  '@humanfs/core@0.19.2':
-    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
-    engines: {node: '>=18.18.0'}
-
   '@humanfs/node@0.16.7':
     resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
-    engines: {node: '>=18.18.0'}
-
-  '@humanfs/node@0.16.8':
-    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
-    engines: {node: '>=18.18.0'}
-
-  '@humanfs/types@0.15.0':
-    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
     engines: {node: '>=18.18.0'}
 
   '@humanwhocodes/module-importer@1.0.1':
@@ -4783,9 +4745,6 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/estree@1.0.9':
-    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
-
   '@types/fs-extra@5.1.0':
     resolution: {integrity: sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==}
 
@@ -5321,9 +5280,6 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
-  ajv@6.15.0:
-    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
-
   ajv@8.12.0:
     resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
 
@@ -5691,9 +5647,6 @@ packages:
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
@@ -6014,19 +5967,19 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  codemirror-lang-glimdown@2.0.3:
-    resolution: {integrity: sha512-06txsPLMT3cA0EfonYPPHSl3Gz/mjMqRCkF3DXvuhNdZwmbEm+Fv24ak2ZFGYSe5OzoYdnTqTbLoUrTNT+jbRA==}
+  codemirror-lang-glimdown@2.0.4:
+    resolution: {integrity: sha512-QPle4W828hgA5GKsLlB9q0K/tf9FOt+qVSZqgE07XGxxtCoZLBhTvotQGQayIVSXPdJeDmBVPacZ0MthaZCXVw==}
     peerDependencies:
       '@codemirror/state': ^6.3.3
       '@codemirror/view': 6.39.12
 
-  codemirror-lang-glimmer-js@2.0.3:
-    resolution: {integrity: sha512-q+GGu/+0nGAovYm8oHZV4o7vKMEXKoachdv7yaoihby+2abBSkHMMELQSyHiM+VJCpBTOleeeVbCSxZLPkpGHg==}
+  codemirror-lang-glimmer-js@2.0.4:
+    resolution: {integrity: sha512-43IzgHUNFMHxZOkWSk2qeAr0sP3pfAm/LfIQk5lj/gvc08CH3K3omV/4uRTFc/qsdl7d4kTXbfU6PqjT4i70qA==}
     peerDependencies:
       '@codemirror/view': 6.39.12
 
-  codemirror-lang-glimmer@2.0.3:
-    resolution: {integrity: sha512-6qmOv4GiNHkVZx41PPGE0xy0Tl+xCHRVM+VRw7ZvjcPLPd99Dg+aXD5ll0MxI29JpqxoyfszwXxhJ7/kxlnfTQ==}
+  codemirror-lang-glimmer@2.0.4:
+    resolution: {integrity: sha512-HaS43Zwrh9MsK6OBR6Y1XnZ5jelRwtjdZnqk1LDtqW0lVxEtnhG8PQSpnd7GjHhA/Sdp7Xiq7TW2LeeyVNcMrA==}
     peerDependencies:
       '@lezer/common': ^1.1.2
 
@@ -6945,8 +6898,8 @@ packages:
       '@ember/test-helpers': '>=3.0.3'
       qunit: ^2.13.0
 
-  ember-repl@8.0.2:
-    resolution: {integrity: sha512-VC8EbLbkO9MY6etm3v2mRHKTE1dCy6GbcpAWJu9zGdmMebOO45d1XelgtAi9QJZBWvnLo0KrkRNFRhLrJNcD0Q==}
+  ember-repl@8.1.0:
+    resolution: {integrity: sha512-XO3ryrvnik72AZrhRcGjlAJe6IjI9Vi7EaZghW8y/a1oSdiP2SL/j1DP/e5zOfDvTOxvAcPwHJVWOKH2KTyrCw==}
     peerDependencies:
       '@glint/template': 1.7.7
     peerDependenciesMeta:
@@ -7270,16 +7223,6 @@ packages:
 
   eslint@9.39.2:
     resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    hasBin: true
-    peerDependencies:
-      jiti: '*'
-    peerDependenciesMeta:
-      jiti:
-        optional: true
-
-  eslint@9.39.5:
-    resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -8233,10 +8176,6 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
-    hasBin: true
-
   jscodeshift@0.15.2:
     resolution: {integrity: sha512-FquR7Okgmc4Sd0aEDwqho3rEiKR3BdvuG9jfdHjLJ6JQoWSMpavug3AoIfnfWhxFlf+5pzQh8qjqz0DWFrNQzA==}
     hasBin: true
@@ -8838,9 +8777,6 @@ packages:
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
-  minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
@@ -9530,11 +9466,6 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  prettier@3.9.6:
-    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
-    engines: {node: '>=14'}
-    hasBin: true
-
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -9802,8 +9733,8 @@ packages:
   remove-types@1.0.0:
     resolution: {integrity: sha512-G7Hk1Q+UJ5DvlNAoJZObxANkBZGiGdp589rVcTW/tYqJWJ5rwfraSnKSQaETN8Epaytw8J40nS/zC7bcHGv36w==}
 
-  repl-sdk@1.5.2:
-    resolution: {integrity: sha512-bMuBmrYt/jjQZH3d7qeJWlJAilAr6/mPtrpWpjFKsa51mGRC+BY0tPanhyehDYa4bWpi3JWlGXzP8ljPJXdGCw==}
+  repl-sdk@1.6.0:
+    resolution: {integrity: sha512-zgf2dJy/Vnei15WZ9keI/YR/g1LRwk6AKD6F96oEQiHQdnqpQEWH1CS6Ua0iA89Iyo1SGM/Qmufp67rNvNGKnQ==}
 
   request-light@0.7.0:
     resolution: {integrity: sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==}
@@ -11557,47 +11488,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/core@7.29.7':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
-      '@babel/helpers': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/eslint-parser@7.28.6(35b07cbf7c313e9df11dc933ad857aba)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-visitor-keys: 2.1.0
-      semver: 6.3.1
-
   '@babel/eslint-parser@7.28.6(90dd1a00afcf438c00236a42e271b90b)':
     dependencies:
       '@babel/core': 7.29.0
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
       eslint: 9.39.2(jiti@2.6.1)
-      eslint-visitor-keys: 2.1.0
-      semver: 6.3.1
-
-  '@babel/eslint-parser@7.28.6(a99f9cc4e2af183fcc21ebce0a944bb6)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 9.39.5(jiti@2.6.1)
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
@@ -11628,19 +11523,6 @@ snapshots:
       '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
       '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.0)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/traverse': 7.29.7
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-member-expression-to-functions': 7.29.7
-      '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
       '@babel/traverse': 7.29.7
       semver: 6.3.1
@@ -11690,15 +11572,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-optimise-call-expression@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
@@ -11717,15 +11590,6 @@ snapshots:
   '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-member-expression-to-functions': 7.29.7
-      '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/traverse': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
       '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
       '@babel/traverse': 7.29.7
@@ -11754,11 +11618,6 @@ snapshots:
       - supports-color
 
   '@babel/helpers@7.28.6':
-    dependencies:
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
-
-  '@babel/helpers@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
@@ -11827,15 +11686,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -11861,11 +11711,6 @@ snapshots:
   '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.0)':
@@ -13186,19 +13031,9 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.10.1(eslint@9.39.5(jiti@2.6.1))':
-    dependencies:
-      eslint: 9.39.5(jiti@2.6.1)
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
-      eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.5(jiti@2.6.1))':
-    dependencies:
-      eslint: 9.39.5(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -13208,14 +13043,6 @@ snapshots:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@8.1.1)
       minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@eslint/config-array@0.21.2':
-    dependencies:
-      '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@8.1.1)
-      minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
@@ -13241,23 +13068,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/eslintrc@3.3.6':
-    dependencies:
-      ajv: 6.15.0
-      debug: 4.4.3(supports-color@8.1.1)
-      espree: 10.4.0
-      globals: 14.0.0
-      ignore: 5.3.2
-      import-fresh: 3.3.1
-      js-yaml: 4.3.0
-      minimatch: 3.1.5
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@eslint/js@9.39.2': {}
-
-  '@eslint/js@9.39.5': {}
 
   '@eslint/object-schema@2.1.7': {}
 
@@ -13411,22 +13222,10 @@ snapshots:
 
   '@humanfs/core@0.19.1': {}
 
-  '@humanfs/core@0.19.2':
-    dependencies:
-      '@humanfs/types': 0.15.0
-
   '@humanfs/node@0.16.7':
     dependencies:
       '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.4.3
-
-  '@humanfs/node@0.16.8':
-    dependencies:
-      '@humanfs/core': 0.19.2
-      '@humanfs/types': 0.15.0
-      '@humanwhocodes/retry': 0.4.3
-
-  '@humanfs/types@0.15.0': {}
 
   '@humanwhocodes/module-importer@1.0.1': {}
 
@@ -13804,32 +13603,6 @@ snapshots:
     dependencies:
       which: 5.0.0
 
-  '@nullvoxpopuli/eslint-configs@5.5.0(066eb5d36fe40fce3e130e3794ecd49a)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@eslint/js': 9.39.2
-      '@typescript-eslint/parser': 8.54.0(141d1b4b90329612287830824a1f2c8f)
-      cosmiconfig: 9.0.0(typescript@5.9.3)
-      ember-eslint: 0.6.1(fb994567383906215be3f6e899d5713a)
-      eslint: 9.39.5(jiti@2.6.1)
-      eslint-import-resolver-typescript: 4.4.4(92fdf5ca1ddd35d2269f7e6ea99dd50a)
-      eslint-plugin-decorator-position: 6.0.0(e9ec93c1cbd00b8477c25481d4b19f19)
-      eslint-plugin-import: 2.32.0(e5c4e31188a281569fee231761b5b744)
-      eslint-plugin-json: 4.0.1
-      eslint-plugin-n: 17.23.2(141d1b4b90329612287830824a1f2c8f)
-      eslint-plugin-simple-import-sort: 12.1.1(eslint@9.39.5(jiti@2.6.1))
-      globals: 16.5.0
-      prettier-plugin-ember-template-tag: 2.1.2(prettier@3.9.6)
-    optionalDependencies:
-      '@babel/eslint-parser': 7.28.6(a99f9cc4e2af183fcc21ebce0a944bb6)
-      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
-      prettier: 3.9.6
-    transitivePeerDependencies:
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - supports-color
-      - typescript
-
   '@nullvoxpopuli/eslint-configs@5.5.0(753b90aa58c0521fb787daa9416104f1)':
     dependencies:
       '@babel/core': 7.29.0
@@ -13849,31 +13622,6 @@ snapshots:
     optionalDependencies:
       '@babel/eslint-parser': 7.28.6(90dd1a00afcf438c00236a42e271b90b)
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.0)
-      prettier: 3.8.1
-    transitivePeerDependencies:
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - supports-color
-      - typescript
-
-  '@nullvoxpopuli/eslint-configs@5.5.0(80764094b1320bd5efa87f121ad32aaf)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@eslint/js': 9.39.2
-      '@typescript-eslint/parser': 8.54.0(b1cbe766652296b79becebe56b05ba7c)
-      cosmiconfig: 9.0.0(typescript@5.9.3)
-      ember-eslint: 0.6.1(948211551132f69df38b149ac821eeca)
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-typescript: 4.4.4(dc699ced992fcedfde63643dc55ed36e)
-      eslint-plugin-decorator-position: 6.0.0(9b9abbcf44b3a102127f8ef62d533690)
-      eslint-plugin-import: 2.32.0(da3cf411676f31e1ee575d09083acbfe)
-      eslint-plugin-json: 4.0.1
-      eslint-plugin-n: 17.23.2(b1cbe766652296b79becebe56b05ba7c)
-      eslint-plugin-simple-import-sort: 12.1.1(eslint@9.39.2(jiti@2.6.1))
-      globals: 16.5.0
-      prettier-plugin-ember-template-tag: 2.1.2(prettier@3.8.1)
-    optionalDependencies:
-      '@babel/eslint-parser': 7.28.6(35b07cbf7c313e9df11dc933ad857aba)
       prettier: 3.8.1
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
@@ -14675,8 +14423,6 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/estree@1.0.9': {}
-
   '@types/fs-extra@5.1.0':
     dependencies:
       '@types/node': 24.10.9
@@ -14784,22 +14530,6 @@ snapshots:
       '@types/node': 24.10.9
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.54.0(366361b1ed8db5882a01c7408d2a5757)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.54.0(141d1b4b90329612287830824a1f2c8f)
-      '@typescript-eslint/scope-manager': 8.54.0
-      '@typescript-eslint/type-utils': 8.54.0(141d1b4b90329612287830824a1f2c8f)
-      '@typescript-eslint/utils': 8.54.0(141d1b4b90329612287830824a1f2c8f)
-      '@typescript-eslint/visitor-keys': 8.54.0
-      eslint: 9.39.5(jiti@2.6.1)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@8.54.0(8cba54b1ce8d4815212ee8a3ae487b8b)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -14812,18 +14542,6 @@ snapshots:
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@8.54.0(141d1b4b90329612287830824a1f2c8f)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.54.0
-      '@typescript-eslint/types': 8.54.0
-      '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.54.0
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.5(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -14858,18 +14576,6 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.54.0(141d1b4b90329612287830824a1f2c8f)':
-    dependencies:
-      '@typescript-eslint/types': 8.54.0
-      '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.54.0(141d1b4b90329612287830824a1f2c8f)
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.5(jiti@2.6.1)
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/type-utils@8.54.0(b1cbe766652296b79becebe56b05ba7c)':
     dependencies:
       '@typescript-eslint/types': 8.54.0
@@ -14895,17 +14601,6 @@ snapshots:
       semver: 7.8.5
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.54.0(141d1b4b90329612287830824a1f2c8f)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.54.0
-      '@typescript-eslint/types': 8.54.0
-      '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
-      eslint: 9.39.5(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -15429,13 +15124,6 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@6.15.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-json-stable-stringify: 2.1.0
-      json-schema-traverse: 0.4.1
-      uri-js: 4.4.1
-
   ajv@8.12.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -15817,11 +15505,6 @@ snapshots:
   boolbase@1.0.0: {}
 
   brace-expansion@1.1.12:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -16352,7 +16035,7 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  codemirror-lang-glimdown@2.0.3(ec1f15af7e31282ca33da9719a65df5a):
+  codemirror-lang-glimdown@2.0.4(ec1f15af7e31282ca33da9719a65df5a):
     dependencies:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/lang-javascript': 6.2.4
@@ -16369,15 +16052,15 @@ snapshots:
       '@lezer/lr': 1.4.8
       '@lezer/markdown': 1.6.3
       '@replit/codemirror-lang-svelte': 6.0.0(9467715ca32889163bd7161ba7fdb3d1)
-      codemirror-lang-glimmer: 2.0.3(@lezer/common@1.5.0)
-      codemirror-lang-glimmer-js: 2.0.3(a82e47558070302726807efd21dd0cda)
+      codemirror-lang-glimmer: 2.0.4(@lezer/common@1.5.0)
+      codemirror-lang-glimmer-js: 2.0.4(a82e47558070302726807efd21dd0cda)
       codemirror-lang-mermaid: 0.5.0
     transitivePeerDependencies:
       - '@codemirror/autocomplete'
       - '@codemirror/lang-css'
       - '@codemirror/language'
 
-  codemirror-lang-glimmer-js@2.0.3(a82e47558070302726807efd21dd0cda):
+  codemirror-lang-glimmer-js@2.0.4(a82e47558070302726807efd21dd0cda):
     dependencies:
       '@codemirror/lang-css': 6.3.1
       '@codemirror/lang-html': 6.4.11
@@ -16387,11 +16070,11 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/javascript': 1.5.4
       '@lezer/lr': 1.4.8
-      codemirror-lang-glimmer: 2.0.3(@lezer/common@1.5.0)
+      codemirror-lang-glimmer: 2.0.4(@lezer/common@1.5.0)
     transitivePeerDependencies:
       - '@lezer/common'
 
-  codemirror-lang-glimmer@2.0.3(@lezer/common@1.5.0):
+  codemirror-lang-glimmer@2.0.4(@lezer/common@1.5.0):
     dependencies:
       '@codemirror/autocomplete': 6.20.0
       '@codemirror/lang-css': 6.3.1
@@ -16880,13 +16563,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
 
-  decorator-transforms@2.3.1(@babel/core@7.29.7):
-    dependencies:
-      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7)
-      babel-import-util: 3.0.1
-    transitivePeerDependencies:
-      - '@babel/core'
-
   decorator-transforms@2.3.2(@babel/core@7.29.0):
     dependencies:
       '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.0)
@@ -17234,40 +16910,6 @@ snapshots:
       - eslint
       - typescript
 
-  ember-eslint-parser@0.5.13(948211551132f69df38b149ac821eeca):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/eslint-parser': 7.28.6(35b07cbf7c313e9df11dc933ad857aba)
-      '@glimmer/syntax': 0.95.0
-      '@typescript-eslint/tsconfig-utils': 8.54.0(typescript@5.9.3)
-      content-tag: 2.0.3
-      eslint-scope: 7.2.2
-      html-tags: 3.3.1
-      mathml-tag-names: 2.1.3
-      svg-tags: 1.0.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.54.0(b1cbe766652296b79becebe56b05ba7c)
-    transitivePeerDependencies:
-      - eslint
-      - typescript
-
-  ember-eslint-parser@0.5.13(fb994567383906215be3f6e899d5713a):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/eslint-parser': 7.28.6(a99f9cc4e2af183fcc21ebce0a944bb6)
-      '@glimmer/syntax': 0.95.0
-      '@typescript-eslint/tsconfig-utils': 8.54.0(typescript@5.9.3)
-      content-tag: 2.0.3
-      eslint-scope: 7.2.2
-      html-tags: 3.3.1
-      mathml-tag-names: 2.1.3
-      svg-tags: 1.0.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.54.0(141d1b4b90329612287830824a1f2c8f)
-    transitivePeerDependencies:
-      - eslint
-      - typescript
-
   ember-eslint@0.6.1(5a7f00948a6312db668ed12e548f3346):
     dependencies:
       '@babel/eslint-parser': 7.28.6(90dd1a00afcf438c00236a42e271b90b)
@@ -17278,40 +16920,6 @@ snapshots:
       eslint-plugin-qunit: 8.2.5(eslint@9.39.2(jiti@2.6.1))
       globals: 16.5.0
       typescript-eslint: 8.54.0(b1cbe766652296b79becebe56b05ba7c)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@typescript-eslint/parser'
-      - eslint
-      - supports-color
-      - typescript
-
-  ember-eslint@0.6.1(948211551132f69df38b149ac821eeca):
-    dependencies:
-      '@babel/eslint-parser': 7.28.6(35b07cbf7c313e9df11dc933ad857aba)
-      '@eslint/js': 9.39.2
-      eslint-config-prettier: 10.1.8(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-ember: 12.7.5(948211551132f69df38b149ac821eeca)
-      eslint-plugin-n: 17.23.2(b1cbe766652296b79becebe56b05ba7c)
-      eslint-plugin-qunit: 8.2.5(eslint@9.39.2(jiti@2.6.1))
-      globals: 16.5.0
-      typescript-eslint: 8.54.0(b1cbe766652296b79becebe56b05ba7c)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@typescript-eslint/parser'
-      - eslint
-      - supports-color
-      - typescript
-
-  ember-eslint@0.6.1(fb994567383906215be3f6e899d5713a):
-    dependencies:
-      '@babel/eslint-parser': 7.28.6(a99f9cc4e2af183fcc21ebce0a944bb6)
-      '@eslint/js': 9.39.2
-      eslint-config-prettier: 10.1.8(eslint@9.39.5(jiti@2.6.1))
-      eslint-plugin-ember: 12.7.5(fb994567383906215be3f6e899d5713a)
-      eslint-plugin-n: 17.23.2(141d1b4b90329612287830824a1f2c8f)
-      eslint-plugin-qunit: 8.2.5(eslint@9.39.5(jiti@2.6.1))
-      globals: 16.5.0
-      typescript-eslint: 8.54.0(141d1b4b90329612287830824a1f2c8f)
     transitivePeerDependencies:
       - '@babel/core'
       - '@typescript-eslint/parser'
@@ -17474,17 +17082,17 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  ember-repl@8.0.2(97a2ca31a8e4cf9a385bac208eb0c5f1):
+  ember-repl@8.1.0(97a2ca31a8e4cf9a385bac208eb0c5f1):
     dependencies:
       '@ember/test-helpers': 5.4.1(c8332dc3f90c0e60eb130a3a85f980b9)
       '@ember/test-waiters': 4.1.2
       codemirror: 6.0.2
-      content-tag: 4.1.1
+      content-tag: 4.2.0
       decorator-transforms: 2.3.1(@babel/core@7.29.0)
       ember-primitives: 0.51.0(a64917a33376b7be2998bd4d1c9f349f)
       ember-resolver: 13.1.1
       ember-resources: 7.1.0(5417512ae382abcafe5679ee7b1ac481)
-      repl-sdk: 1.5.2(93d4969b5698d0d4464d33ccc0660007)
+      repl-sdk: 1.6.0(93d4969b5698d0d4464d33ccc0660007)
     optionalDependencies:
       '@glint/template': 1.7.7
     transitivePeerDependencies:
@@ -17714,18 +17322,9 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)
       semver: 7.8.1
 
-  eslint-compat-utils@0.5.1(eslint@9.39.5(jiti@2.6.1)):
-    dependencies:
-      eslint: 9.39.5(jiti@2.6.1)
-      semver: 7.8.1
-
   eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
-
-  eslint-config-prettier@10.1.8(eslint@9.39.5(jiti@2.6.1)):
-    dependencies:
-      eslint: 9.39.5(jiti@2.6.1)
 
   eslint-import-context@0.1.9(unrs-resolver@1.11.1):
     dependencies:
@@ -17742,21 +17341,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.4.4(92fdf5ca1ddd35d2269f7e6ea99dd50a):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.5(jiti@2.6.1)
-      eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash-x: 0.2.0
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(e5c4e31188a281569fee231761b5b744)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@4.4.4(dc699ced992fcedfde63643dc55ed36e):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -17769,17 +17353,6 @@ snapshots:
       unrs-resolver: 1.11.1
     optionalDependencies:
       eslint-plugin-import: 2.32.0(da3cf411676f31e1ee575d09083acbfe)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(d17e025e076f293b2924af9c97a30f84):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.54.0(141d1b4b90329612287830824a1f2c8f)
-      eslint: 9.39.5(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 4.4.4(92fdf5ca1ddd35d2269f7e6ea99dd50a)
     transitivePeerDependencies:
       - supports-color
 
@@ -17807,32 +17380,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-decorator-position@6.0.0(9b9abbcf44b3a102127f8ef62d533690):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.0)
-      '@ember-data/rfc395-data': 0.0.4
-      ember-rfc176-data: 0.3.18
-      eslint: 9.39.2(jiti@2.6.1)
-      snake-case: 3.0.4
-    optionalDependencies:
-      '@babel/eslint-parser': 7.28.6(35b07cbf7c313e9df11dc933ad857aba)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-plugin-decorator-position@6.0.0(e9ec93c1cbd00b8477c25481d4b19f19):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.0)
-      '@ember-data/rfc395-data': 0.0.4
-      ember-rfc176-data: 0.3.18
-      eslint: 9.39.5(jiti@2.6.1)
-      snake-case: 3.0.4
-    optionalDependencies:
-      '@babel/eslint-parser': 7.28.6(a99f9cc4e2af183fcc21ebce0a944bb6)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-plugin-ember@12.7.5(5a7f00948a6312db668ed12e548f3346):
     dependencies:
       '@ember-data/rfc395-data': 0.0.4
@@ -17852,57 +17399,12 @@ snapshots:
       - '@babel/core'
       - typescript
 
-  eslint-plugin-ember@12.7.5(948211551132f69df38b149ac821eeca):
-    dependencies:
-      '@ember-data/rfc395-data': 0.0.4
-      css-tree: 3.1.0
-      ember-eslint-parser: 0.5.13(948211551132f69df38b149ac821eeca)
-      ember-rfc176-data: 0.3.18
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-utils: 3.0.0(eslint@9.39.2(jiti@2.6.1))
-      estraverse: 5.3.0
-      lodash.camelcase: 4.3.0
-      lodash.kebabcase: 4.1.1
-      requireindex: 1.2.0
-      snake-case: 3.0.4
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.54.0(b1cbe766652296b79becebe56b05ba7c)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - typescript
-
-  eslint-plugin-ember@12.7.5(fb994567383906215be3f6e899d5713a):
-    dependencies:
-      '@ember-data/rfc395-data': 0.0.4
-      css-tree: 3.1.0
-      ember-eslint-parser: 0.5.13(fb994567383906215be3f6e899d5713a)
-      ember-rfc176-data: 0.3.18
-      eslint: 9.39.5(jiti@2.6.1)
-      eslint-utils: 3.0.0(eslint@9.39.5(jiti@2.6.1))
-      estraverse: 5.3.0
-      lodash.camelcase: 4.3.0
-      lodash.kebabcase: 4.1.1
-      requireindex: 1.2.0
-      snake-case: 3.0.4
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.54.0(141d1b4b90329612287830824a1f2c8f)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - typescript
-
   eslint-plugin-es-x@7.8.0(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       eslint: 9.39.2(jiti@2.6.1)
       eslint-compat-utils: 0.5.1(eslint@9.39.2(jiti@2.6.1))
-
-  eslint-plugin-es-x@7.8.0(eslint@9.39.5(jiti@2.6.1)):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.6.1))
-      '@eslint-community/regexpp': 4.12.2
-      eslint: 9.39.5(jiti@2.6.1)
-      eslint-compat-utils: 0.5.1(eslint@9.39.5(jiti@2.6.1))
 
   eslint-plugin-import@2.32.0(da3cf411676f31e1ee575d09083acbfe):
     dependencies:
@@ -17933,54 +17435,10 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(e5c4e31188a281569fee231761b5b744):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: '@nolyfill/array-includes@1.0.44'
-      array.prototype.findlastindex: '@nolyfill/array.prototype.findlastindex@1.0.44'
-      array.prototype.flat: '@nolyfill/array.prototype.flat@1.0.44'
-      array.prototype.flatmap: '@nolyfill/array.prototype.flatmap@1.0.44'
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.39.5(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(d17e025e076f293b2924af9c97a30f84)
-      hasown: '@nolyfill/hasown@1.0.44'
-      is-core-module: '@nolyfill/is-core-module@1.0.39'
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: '@nolyfill/object.fromentries@1.0.44'
-      object.groupby: '@nolyfill/object.groupby@1.0.44'
-      object.values: '@nolyfill/object.values@1.0.44'
-      semver: 6.3.1
-      string.prototype.trimend: '@nolyfill/string.prototype.trimend@1.0.44'
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.54.0(141d1b4b90329612287830824a1f2c8f)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
   eslint-plugin-json@4.0.1:
     dependencies:
       lodash: 4.18.1
       vscode-json-languageservice: 4.2.1
-
-  eslint-plugin-n@17.23.2(141d1b4b90329612287830824a1f2c8f):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.6.1))
-      enhanced-resolve: 5.18.4
-      eslint: 9.39.5(jiti@2.6.1)
-      eslint-plugin-es-x: 7.8.0(eslint@9.39.5(jiti@2.6.1))
-      get-tsconfig: 4.13.0
-      globals: 15.15.0
-      globrex: 0.1.2
-      ignore: 5.3.2
-      semver: 7.8.1
-      ts-declaration-location: 1.0.7(typescript@5.9.3)
-    transitivePeerDependencies:
-      - typescript
 
   eslint-plugin-n@17.23.2(b1cbe766652296b79becebe56b05ba7c):
     dependencies:
@@ -18004,20 +17462,9 @@ snapshots:
     transitivePeerDependencies:
       - eslint
 
-  eslint-plugin-qunit@8.2.5(eslint@9.39.5(jiti@2.6.1)):
-    dependencies:
-      eslint-utils: 3.0.0(eslint@9.39.5(jiti@2.6.1))
-      requireindex: 1.2.0
-    transitivePeerDependencies:
-      - eslint
-
   eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
-
-  eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.5(jiti@2.6.1)):
-    dependencies:
-      eslint: 9.39.5(jiti@2.6.1)
 
   eslint-scope@5.1.1:
     dependencies:
@@ -18037,11 +17484,6 @@ snapshots:
   eslint-utils@3.0.0(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
-      eslint-visitor-keys: 2.1.0
-
-  eslint-utils@3.0.0(eslint@9.39.5(jiti@2.6.1)):
-    dependencies:
-      eslint: 9.39.5(jiti@2.6.1)
       eslint-visitor-keys: 2.1.0
 
   eslint-visitor-keys@2.1.0: {}
@@ -18084,47 +17526,6 @@ snapshots:
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
       minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    optionalDependencies:
-      jiti: 2.6.1
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint@9.39.5(jiti@2.6.1):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5(jiti@2.6.1))
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
-      '@eslint/config-helpers': 0.4.2
-      '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.6
-      '@eslint/js': 9.39.5
-      '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.8
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.9
-      ajv: 6.15.0
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
-      escape-string-regexp: 4.0.0
-      eslint-scope: 8.4.0
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      esquery: 1.7.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -19249,10 +18650,6 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@4.3.0:
-    dependencies:
-      argparse: 2.0.1
-
   jscodeshift@0.15.2(df563b4db34a4f08227991cffd9a99b7):
     dependencies:
       '@babel/core': 7.29.0
@@ -19400,7 +18797,7 @@ snapshots:
       decorator-transforms: 2.4.0(@babel/core@7.29.0)
       ember-modifier: 4.3.0(@babel/core@7.29.0)
       ember-primitives: 0.48.2(a64917a33376b7be2998bd4d1c9f349f)
-      ember-repl: 8.0.2(97a2ca31a8e4cf9a385bac208eb0c5f1)
+      ember-repl: 8.1.0(97a2ca31a8e4cf9a385bac208eb0c5f1)
       ember-resources: 7.1.0(5417512ae382abcafe5679ee7b1ac481)
       globby: 16.1.0
       json5: 2.2.3
@@ -20101,10 +19498,6 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
-  minimatch@3.1.5:
-    dependencies:
-      brace-expansion: 1.1.16
-
   minimatch@5.1.9:
     dependencies:
       brace-expansion: 2.1.1
@@ -20760,14 +20153,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  prettier-plugin-ember-template-tag@2.1.2(prettier@3.9.6):
-    dependencies:
-      '@babel/core': 7.29.0
-      content-tag: 4.1.1
-      prettier: 3.9.6
-    transitivePeerDependencies:
-      - supports-color
-
   prettier-plugin-tailwindcss@0.7.2(prettier@3.8.1):
     dependencies:
       prettier: 3.8.1
@@ -20775,8 +20160,6 @@ snapshots:
   prettier@2.8.8: {}
 
   prettier@3.8.1: {}
-
-  prettier@3.9.6: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -21143,7 +20526,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  repl-sdk@1.5.2(93d4969b5698d0d4464d33ccc0660007):
+  repl-sdk@1.6.0(93d4969b5698d0d4464d33ccc0660007):
     dependencies:
       '@codemirror/autocomplete': 6.20.0
       '@codemirror/commands': 6.10.1
@@ -21166,9 +20549,9 @@ snapshots:
       '@shikijs/rehype': 3.23.0
       change-case: 5.4.4
       codemirror: 6.0.2
-      codemirror-lang-glimdown: 2.0.3(ec1f15af7e31282ca33da9719a65df5a)
-      codemirror-lang-glimmer: 2.0.3(@lezer/common@1.5.0)
-      codemirror-lang-glimmer-js: 2.0.3(a82e47558070302726807efd21dd0cda)
+      codemirror-lang-glimdown: 2.0.4(ec1f15af7e31282ca33da9719a65df5a)
+      codemirror-lang-glimmer: 2.0.4(@lezer/common@1.5.0)
+      codemirror-lang-glimmer-js: 2.0.4(a82e47558070302726807efd21dd0cda)
       codemirror-lang-mermaid: 0.5.0
       codemirror-languageserver: 1.18.1(encoding@0.1.13)
       comlink: 4.4.2
@@ -22411,17 +21794,6 @@ snapshots:
   typescript-auto-import-cache@0.3.6:
     dependencies:
       semver: 7.8.1
-
-  typescript-eslint@8.54.0(141d1b4b90329612287830824a1f2c8f):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.54.0(366361b1ed8db5882a01c7408d2a5757)
-      '@typescript-eslint/parser': 8.54.0(141d1b4b90329612287830824a1f2c8f)
-      '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.54.0(141d1b4b90329612287830824a1f2c8f)
-      eslint: 9.39.5(jiti@2.6.1)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
 
   typescript-eslint@8.54.0(b1cbe766652296b79becebe56b05ba7c):
     dependencies:


### PR DESCRIPTION
## The problem

When an error is trapped during `content-tag` preprocessing (a gjs parse error), the UI's error bubble only showed:

```
Parse Error at dynamic-repl.js:1:18: 1:19
```

That's because SWC (via content-tag's `Preprocessor#process`) throws an `Error` whose `message` is only the location line — the explanation of *what* is wrong and the code frame live on a non-standard `source_code` own-property (there's also `source_code_color`, and `stack` is nothing but wasm frames):

```
own keys: [ 'stack', 'message', 'source_code', 'source_code_color' ]
```

`repl-sdk`'s `compile()` catch did `e instanceof Error ? e.message : e`, so `source_code` was dropped on every path to the UI.

## The fix

- **repl-sdk**: new `errorMessage(error)` util (exported from the package root) that combines `message` and `source_code` when present, falling back to the old behavior for everything else. Used when announcing compile errors (`on.log` → `lastError` → the error bubble) and unhandled rejections (which previously announced the raw reason object).
- **ember-repl**: `CompileState#reason` goes through `errorMessage` too, so `state.reason` and `onError` consumers get the full details.

The original error is still rethrown untouched, so nothing is lost programmatically (`stack` and `source_code_color` remain available on the error itself in the console).

The error bubble now shows:

```
Parse Error at dynamic-repl.js:1:18: 1:19

  × Expression expected
   ╭─[dynamic-repl.js:1:1]
 1 │ const isBroken = ;
   ·                  ─
   ╰────
```

(the bubble's `<pre>` is already `white-space: pre-wrap`, so the code frame renders as-is)

## Tests

- `repl-sdk` (vitest): unit tests for `errorMessage` — non-object throwables, plain `Error`s, and the SWC shape (inline snapshot)
- `ember-repl` (browser): compiles a gjs snippet with a syntax error through the real content-tag wasm and asserts that `state.reason`, `onError`, and `compiler.lastError.message` (the error bubble's source) all include the location, the "Expression expected" explanation, and the code frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)