### PR TITLE
Tutorial: preview the unreleased kolay (docs() plugin rework)

### DIFF
--- a/apps/tutorial/app/components/selection.gts
+++ b/apps/tutorial/app/components/selection.gts
@@ -6,7 +6,7 @@ import { service } from '@ember/service';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { faBars } from '@fortawesome/free-solid-svg-icons';
 import { isCollection } from 'kolay';
-import { isNotHidden, titleize } from 'tutorial/utils';
+import { isNotHidden, lessonPath, titleize } from 'tutorial/utils';
 
 import type RouterService from '@ember/routing/router-service';
 import type DocsService from 'tutorial/services/docs';
@@ -32,10 +32,8 @@ export class Selection extends Component {
     this.router.transitionTo(event.target.value);
   };
 
-  isSelected = (group: { path: string }, tutorial: { path: string }) => {
-    const fullPath = `/${group.path}/${tutorial.path}`;
-
-    return this.docs.currentPath === fullPath;
+  isSelected = (tutorial: Parameters<typeof lessonPath>[0]) => {
+    return this.docs.currentPath === lessonPath(tutorial);
   };
 
   <template>
@@ -71,8 +69,8 @@ export class Selection extends Component {
                   {{#if (isNotHidden tutorial)}}
 
                     <option
-                      value="/{{group.path}}/{{tutorial.path}}"
-                      selected={{this.isSelected group tutorial}}
+                      value={{lessonPath tutorial}}
+                      selected={{this.isSelected tutorial}}
                     >
                       {{titleize tutorial.name}}
                     </option>

--- a/apps/tutorial/app/router.ts
+++ b/apps/tutorial/app/router.ts
@@ -11,5 +11,6 @@ export default class Router extends EmberRouter {
 }
 
 Router.map(function () {
-  addRoutes(this);
+  // scoped mount: the 'docs' group serves from the root URL space
+  addRoutes(this, 'docs');
 });

--- a/apps/tutorial/app/routes/application.ts
+++ b/apps/tutorial/app/routes/application.ts
@@ -15,7 +15,6 @@ export default class ApplicationRoute extends Route {
     const highlighter = await createShiki();
 
     const manifest = await setupKolay(this, {
-      resolve: {},
       rehypePlugins: [
         [
           rehypeShikiFromHighlighter,

--- a/apps/tutorial/app/services/docs.ts
+++ b/apps/tutorial/app/services/docs.ts
@@ -2,6 +2,7 @@ import { cached, tracked } from '@glimmer/tracking';
 import Service, { service } from '@ember/service';
 
 import { docsManager } from 'kolay';
+import { lessonPath } from 'tutorial/utils';
 
 import type Selected from './selected';
 import type RouterService from '@ember/routing/router-service';
@@ -25,6 +26,12 @@ export default class DocsService extends Service {
     return this.docs.tree ?? {};
   }
 
+  get firstLesson(): string | undefined {
+    const first = this.tutorials[0];
+
+    return first ? lessonPath(first) : undefined;
+  }
+
   get showAnswer() {
     return this.router.currentRoute?.queryParams?.['showAnswer'] === '1';
   }
@@ -40,11 +47,11 @@ export default class DocsService extends Service {
   };
 
   get currentPath(): string | undefined {
-    if (!this.router.currentURL) return this.tutorials[0]?.path;
+    if (!this.router.currentURL) return this.firstLesson;
 
     const [path] = this.router.currentURL.split('?');
 
-    return path && path !== '/' ? path : this.tutorials[0]?.path;
+    return path && path !== '/' ? path : this.firstLesson;
   }
 
   toggleProse = () => {

--- a/apps/tutorial/app/services/selected.ts
+++ b/apps/tutorial/app/services/selected.ts
@@ -5,7 +5,7 @@ import { Compiled as MarkdownToHTML } from 'kolay';
 import { keepLatest } from 'reactiveweb/keep-latest';
 import { link } from 'reactiveweb/link';
 import { RemoteData } from 'reactiveweb/remote-data';
-import { nextPage } from 'tutorial/utils';
+import { lessonPath, nextPage } from 'tutorial/utils';
 
 import type DocsService from './docs';
 import type RouterService from '@ember/routing/router-service';
@@ -117,8 +117,8 @@ export default class Selected extends Service {
   }
 
   #findByPath = (path: string) => {
-    const prosePath = `${path}/prose.md`;
-
-    return this.docs.tutorials.find((tutorial) => tutorial.path === prosePath);
+    return this.docs.tutorials.find(
+      (tutorial) => lessonPath(tutorial) === path
+    );
   };
 }

--- a/apps/tutorial/app/utils.ts
+++ b/apps/tutorial/app/utils.ts
@@ -4,14 +4,39 @@ import type { Collection, Page } from 'kolay';
 
 export const not = (x: unknown) => !x;
 
+/**
+ * The manifest's page paths live under the 'docs' group
+ * (e.g. /docs/1-introduction/1-basics/prose.md), but the app's URLs are
+ * the lesson directories at the root (e.g. /1-introduction/1-basics) —
+ * the group is mounted at the root via addRoutes(this, 'docs').
+ */
+export function lessonPath(item: Page | Collection): string {
+  return item.appRelativePath
+    .replace(/^\/docs/, '')
+    .replace(/\/prose\.md$/, '');
+}
+
+/**
+ * keyed-each-blocks is only shown in dev builds.
+ * Pending: https://github.com/emberjs/ember.js/issues/20419
+ */
+const isProdOnlyHidden = (path: string) =>
+  import.meta.env.PROD && path.includes('keyed-each-blocks');
+
 export function isHidden(page: Page | Collection) {
+  // Only lesson directories (via their prose.md) are tutorial entries.
+  // Stray .md files next to the lesson directories have no prompt/answer
+  // and never had manifest entries before the kolay rework.
+  if (!isCollection(page) && !page.path.endsWith('/prose.md')) return true;
+
   if (location.href.includes('showHidden')) return false;
 
-  if (isCollection(page)) {
-    return page.path.startsWith('x-');
-  }
+  const path = isCollection(page) ? page.path : lessonPath(page);
 
-  return page.path.startsWith('/x-');
+  return (
+    path.split('/').some((segment) => segment.startsWith('x-')) ||
+    isProdOnlyHidden(path)
+  );
 }
 
 export function isNotHidden(page: Page | Collection) {
@@ -30,9 +55,9 @@ export function nextPage(
     }
 
     if (found) {
-      preload(tutorial.path);
+      preload(lessonPath(tutorial));
 
-      return unprose(tutorial.path);
+      return lessonPath(tutorial);
     }
 
     if (current?.path && current.path === tutorial.path) {
@@ -43,27 +68,19 @@ export function nextPage(
   return;
 }
 
-function unprose(prosePath: string | undefined) {
-  if (!prosePath) return;
-
-  return prosePath.replace(/\/prose.md$/, '');
-}
-
 /**
  * To help reduce load time between chapters, we'll load
  * the next and previous documents for each page
  */
-async function preload(prosePath?: string) {
-  if (!prosePath) return;
+async function preload(path?: string) {
+  if (!path) return;
 
   await Promise.resolve();
 
-  const path = unprose(prosePath);
-
   await Promise.all([
-    fetch(`/docs/${path}/prose.md`),
-    fetch(`/docs/${path}/prompt.gjs`),
-    fetch(`/docs/${path}/answer.gjs`),
+    fetch(`/docs${path}/prose.md`),
+    fetch(`/docs${path}/prompt.gjs`),
+    fetch(`/docs${path}/answer.gjs`),
   ]);
 }
 

--- a/apps/tutorial/tests/application/visitable-test.gts
+++ b/apps/tutorial/tests/application/visitable-test.gts
@@ -18,7 +18,9 @@ import { tmpData } from './tmp';
 
 import type { Manifest } from 'kolay';
 
-const manifest = tmpData as Manifest;
+// tmpData is a snapshot of the pre-rework manifest shape; the test only
+// uses it to enumerate lesson URLs, which are unchanged.
+const manifest = tmpData as unknown as Manifest;
 
 module('every tutorial chapter', function (hooks) {
   setupApplicationTest(hooks);

--- a/apps/tutorial/tests/helpers/mocks.ts
+++ b/apps/tutorial/tests/helpers/mocks.ts
@@ -24,11 +24,14 @@ function makeDocsTree(treeData: [string, string[]][]) {
 
       const page = {
         path: tutorialPath,
+        // as in the real manifest: the 'docs' group prefixes appRelativePath
+        appRelativePath: `/docs/${groupPath}/${tutorialPath}`,
         name: tutorialName,
         cleanedName: tutorialName.replace(/-/g, ' '),
         pages: [
           {
             path: prosePath,
+            appRelativePath: `/docs${prosePath}`,
             name: 'prose',
             groupName: tutorialName.replace(/-/g, ' '),
             cleanedName: 'prose',
@@ -42,6 +45,7 @@ function makeDocsTree(treeData: [string, string[]][]) {
 
     const group = {
       path: groupPath,
+      appRelativePath: `/docs/${groupPath}`,
       name: groupName,
       cleanedName: groupName.replace(/-/g, ' '),
       pages: groupPages,

--- a/apps/tutorial/vite.config.js
+++ b/apps/tutorial/vite.config.js
@@ -1,14 +1,22 @@
 import { ember, extensions } from '@embroider/vite';
 
 import { babel } from '@rollup/plugin-babel';
-import { kolay } from 'kolay/vite';
+import { docs } from 'kolay/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig(
-  ({ mode /* command, isSsrBuild, isPreview */ }) => ({
+  (/* { mode, command, isSsrBuild, isPreview } */) => ({
     build: {
       sourcemap: true,
       minify: 'terser',
+      /**
+       * Vite's default cssTarget predates light-dark(), so lightningcss
+       * rewrites it into var(--lightningcss-light/dark) space toggles whose
+       * :root definitions don't survive chunking, invalidating the
+       * declarations (kolay ships light-dark() colors). These targets
+       * support light-dark() natively, so it ships as authored.
+       */
+      cssTarget: ['chrome123', 'firefox120', 'safari17.5'],
     },
     resolve: {
       extensions,
@@ -17,10 +25,12 @@ export default defineConfig(
       postcss: './config/postcss.config.mjs',
     },
     optimizeDeps: {
-      // a wasm-providing dependency
       exclude: [
+        // a wasm-providing dependency
         'content-tag',
-        // 'ember-repl'
+        // stateful: the scoped-route registry must be a single module
+        // instance between the router (addRoutes) and the docs service
+        'kolay',
       ],
       // for top-level-await, etc
       esbuildOptions: {
@@ -28,18 +38,7 @@ export default defineConfig(
       },
     },
     plugins: [
-      kolay({
-        src: 'public/docs',
-        /**
-         * Pending: https://github.com/emberjs/ember.js/issues/20419
-         */
-        exclude: mode === 'production' ? [/^x-/, 'keyed-each-blocks'] : [],
-        /**
-         * This project has convention a based manifest so we only need directories
-         */
-        onlyDirectories: true,
-        packages: [],
-      }),
+      docs('docs', { src: import.meta.resolve('./public/docs') }),
       ember(),
       babel({
         babelHelpers: 'runtime',

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
       "object.values": "npm:@nolyfill/object.values@^1",
       "reactiveweb": "1.9.1",
       "@codemirror/view": "6.39.12",
+      "kolay": "github:universal-ember/kolay#dist",
       "kolay>ember-repl": "^8.0.0",
       "side-channel": "npm:@nolyfill/side-channel@^1",
       "string.prototype.matchall": "npm:@nolyfill/string.prototype.matchall@^1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ overrides:
   object.values: npm:@nolyfill/object.values@^1
   reactiveweb: 1.9.1
   '@codemirror/view': 6.39.12
+  kolay: github:universal-ember/kolay#dist
   kolay>ember-repl: ^8.0.0
   side-channel: npm:@nolyfill/side-channel@^1
   string.prototype.matchall: npm:@nolyfill/string.prototype.matchall@^1
@@ -470,8 +471,8 @@ importers:
         specifier: ^7.1.0
         version: 7.1.0(5417512ae382abcafe5679ee7b1ac481)
       kolay:
-        specifier: ^4.1.0
-        version: 4.1.0(b186acb6a5fb3b0afbb6a8a87202195b)
+        specifier: github:universal-ember/kolay#dist
+        version: https://codeload.github.com/universal-ember/kolay/tar.gz/954694ac6eac09a27d22b71762f83ecad7080345(0d7798950681c8d6f11c89df9fde55ef)
       limber-ui:
         specifier: workspace:*
         version: link:../../packages/limber-ui
@@ -6829,21 +6830,6 @@ packages:
     resolution: {integrity: sha512-fedRHUsvq8tIZgOii8jTrfAyeq+la/9H5eAzhNNwEyzo7nDMmqK2SxsyBUGXprd8fOacsPabLlzlucMi/4mUpA==}
     engines: {node: 16.* || >= 18}
 
-  ember-primitives@0.48.2:
-    resolution: {integrity: sha512-r2IPD1vdq6UxPJqj1mkFXYRGELFLTidQ/doQ5eiOURS7BTjuP7lwjyJH9TbsgRtk1KnstqOgU663AmPHFtwTaQ==}
-    peerDependencies:
-      '@ember/test-helpers': '>= 3.2.0'
-      '@ember/test-waiters': '>= 3.0.2'
-      '@glimmer/component': ^2.0.0
-      '@glint/template': 1.7.7
-      ember-modifier: '>= 4.1.0'
-      ember-resources: '>= 6.1.0'
-    peerDependenciesMeta:
-      '@ember/test-helpers':
-        optional: true
-      '@glint/template':
-        optional: true
-
   ember-primitives@0.51.0:
     resolution: {integrity: sha512-XYb/kiRc08AbIJOPNyP+EABs6TCVCO9VhOXcJ60TC5mTwg0F5nAp8zLzGZVCpyp2EjZ/pS+EtzCTShCIW4ITIQ==}
     hasBin: true
@@ -6862,6 +6848,22 @@ packages:
 
   ember-primitives@0.57.0:
     resolution: {integrity: sha512-bZIQLhTHEBI7/v/5GA8k3MqrR89Vo0AE1IXXuGMEW9Xy8AK3Ia8zwyd7Scezn1AwLJmtQbucjp1Xc/eP2vwlQw==}
+    hasBin: true
+    peerDependencies:
+      '@ember/test-helpers': '>= 3.2.0'
+      '@ember/test-waiters': '>= 3.0.2'
+      '@glimmer/component': ^2.0.0
+      '@glint/template': 1.7.7
+      ember-modifier: '>= 4.1.0'
+      ember-resources: '>= 6.1.0'
+    peerDependenciesMeta:
+      '@ember/test-helpers':
+        optional: true
+      '@glint/template':
+        optional: true
+
+  ember-primitives@0.60.1:
+    resolution: {integrity: sha512-OLUSUM4eqGVaxWGnq3oV1FIBE8JyYUTDTXYWDHd8OHdiFbU10CUJ4A7k6FbpCfBXO7k0Ce+aualiyuIpY28mmg==}
     hasBin: true
     peerDependencies:
       '@ember/test-helpers': '>= 3.2.0'
@@ -7727,6 +7729,10 @@ packages:
     resolution: {integrity: sha512-+A4Hq7m7Ze592k9gZRy4gJ27DrXRNnC1vPjxTt1qQxEY8RxagBkBxivkCwg7FxSTG0iLLEMaUx13oOr0R2/qcQ==}
     engines: {node: '>=20'}
 
+  globby@16.2.2:
+    resolution: {integrity: sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==}
+    engines: {node: '>=20'}
+
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
@@ -8268,8 +8274,9 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
 
-  kolay@4.1.0:
-    resolution: {integrity: sha512-Fkz0c0pHlQkqOkdbjvk3vZAONRZW5K1z/bWTx2Q3Z7SU6a442nm3AzjwAAgJscKYCWPW3s+ncya7l2ucirCueA==}
+  kolay@https://codeload.github.com/universal-ember/kolay/tar.gz/954694ac6eac09a27d22b71762f83ecad7080345:
+    resolution: {gitHosted: true, integrity: sha512-beQHoybQQfO3dbLEc91g+RYoS+1tPhG1QXpElI049GPEeLXVVLf8HWAAD8yHYVbiHoFZPMsn3jiRcqjITd8TwA==, tarball: https://codeload.github.com/universal-ember/kolay/tar.gz/954694ac6eac09a27d22b71762f83ecad7080345}
+    version: 5.4.0
     engines: {node: '>= 18'}
 
   kolorist@1.8.0:
@@ -10658,8 +10665,8 @@ packages:
     peerDependencies:
       typedoc: '>=0.22.x <0.29.x'
 
-  typedoc@0.28.15:
-    resolution: {integrity: sha512-mw2/2vTL7MlT+BVo43lOsufkkd2CJO4zeOSuWQQsiXoV2VuEn7f6IZp2jsUDPmBMABpgR0R5jlcJ2OGEFYmkyg==}
+  typedoc@0.28.16:
+    resolution: {integrity: sha512-x4xW77QC3i5DUFMBp0qjukOTnr/sSg+oEs86nB3LjDslvAmwe/PUGDWbe3GrIqt59oTqoXK5GRK9tAa0sYMiog==}
     engines: {node: '>= 18', pnpm: '>= 10'}
     hasBin: true
     peerDependencies:
@@ -10827,6 +10834,39 @@ packages:
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
+
+  unplugin@3.3.0:
+    resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@farmfe/core': '*'
+      '@rspack/core': '*'
+      bun-types-no-globals: '*'
+      esbuild: '*'
+      rolldown: '*'
+      rollup: '*'
+      unloader: '*'
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      '@farmfe/core':
+        optional: true
+      '@rspack/core':
+        optional: true
+      bun-types-no-globals:
+        optional: true
+      esbuild:
+        optional: true
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      unloader:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -11221,9 +11261,6 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-
-  which-heading-do-i-need@0.2.1:
-    resolution: {integrity: sha512-b5ap7yD34ZfeAf5b33NBg9WyLGfwtmaT6voKrOrEXwrmBA8e9aFLkuOhZNyNi34igZOK5iCb3kOLhS0KvHPjkg==}
 
   which-heading-do-i-need@0.2.4:
     resolution: {integrity: sha512-OS4TyybQkx3HOWqPgw6Xx3ss8U/2U35enMquCbTooT2qEl0bvNFHicwk8V3bhWh3E+WD27NlCNPaXmUXYuafqg==}
@@ -16968,32 +17005,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-primitives@0.48.2(a64917a33376b7be2998bd4d1c9f349f):
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@ember/test-waiters': 4.1.2
-      '@embroider/addon-shim': 1.10.2
-      '@embroider/macros': 1.20.5(c8332dc3f90c0e60eb130a3a85f980b9)
-      '@floating-ui/dom': 1.7.5
-      '@glimmer/component': 2.1.1
-      decorator-transforms: 2.4.0(@babel/core@7.29.0)
-      ember-element-helper: 0.8.8
-      ember-modifier: 4.3.0(@babel/core@7.29.0)
-      ember-resources: 7.1.0(5417512ae382abcafe5679ee7b1ac481)
-      form-data-utils: 0.6.0
-      reactiveweb: 1.9.1(9f91e21669edde5a0835948ba5900801)
-      should-handle-link: 1.3.0
-      tabster: 8.7.0
-      tracked-built-ins: 4.1.2(@babel/core@7.29.0)
-      tracked-toolbox: 2.2.0(@babel/core@7.29.0)
-      which-heading-do-i-need: 0.2.1
-    optionalDependencies:
-      '@ember/test-helpers': 5.4.1(c8332dc3f90c0e60eb130a3a85f980b9)
-      '@glint/template': 1.7.7
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
   ember-primitives@0.51.0(a64917a33376b7be2998bd4d1c9f349f):
     dependencies:
       '@babel/runtime': 7.29.2
@@ -17038,6 +17049,31 @@ snapshots:
       tracked-built-ins: 4.1.2(@babel/core@7.29.0)
       tracked-toolbox: 3.0.0(@babel/core@7.29.0)
       which-heading-do-i-need: 0.2.7
+    optionalDependencies:
+      '@ember/test-helpers': 5.4.1(c8332dc3f90c0e60eb130a3a85f980b9)
+      '@glint/template': 1.7.7
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  ember-primitives@0.60.1(a64917a33376b7be2998bd4d1c9f349f):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@ember/test-waiters': 4.1.2
+      '@embroider/addon-shim': 1.10.2
+      '@floating-ui/dom': 1.7.5
+      '@glimmer/component': 2.1.1
+      decorator-transforms: 2.3.2(@babel/core@7.29.0)
+      ember-element-helper: 0.8.8
+      ember-modifier: 4.3.0(@babel/core@7.29.0)
+      ember-resources: 7.1.0(5417512ae382abcafe5679ee7b1ac481)
+      form-data-utils: 0.6.0
+      reactiveweb: 1.9.1(9f91e21669edde5a0835948ba5900801)
+      should-handle-link: 1.3.0
+      tabster: 8.7.0
+      tracked-built-ins: 4.1.2(@babel/core@7.29.0)
+      tracked-toolbox: 3.0.0(@babel/core@7.29.0)
+      which-heading-do-i-need: 0.4.1
     optionalDependencies:
       '@ember/test-helpers': 5.4.1(c8332dc3f90c0e60eb130a3a85f980b9)
       '@glint/template': 1.7.7
@@ -18182,6 +18218,15 @@ snapshots:
       slash: 5.1.0
       unicorn-magic: 0.4.0
 
+  globby@16.2.2:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      fast-glob: 3.3.3
+      ignore: 7.0.5
+      is-path-inside: 4.0.0
+      slash: 5.1.0
+      unicorn-magic: 0.4.0
+
   globrex@0.1.2: {}
 
   gopd@1.2.0: {}
@@ -18787,38 +18832,56 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  kolay@4.1.0(b186acb6a5fb3b0afbb6a8a87202195b):
+  kolay@https://codeload.github.com/universal-ember/kolay/tar.gz/954694ac6eac09a27d22b71762f83ecad7080345(0d7798950681c8d6f11c89df9fde55ef):
     dependencies:
       '@ember/test-waiters': 4.1.2
       '@embroider/addon-shim': 1.10.2
       '@glimmer/component': 2.1.1
       '@glint/template': 1.7.7
+      change-case: 5.4.4
       common-tags: 1.8.2
+      content-tag: 4.2.0
       decorator-transforms: 2.4.0(@babel/core@7.29.0)
       ember-modifier: 4.3.0(@babel/core@7.29.0)
-      ember-primitives: 0.48.2(a64917a33376b7be2998bd4d1c9f349f)
+      ember-primitives: 0.60.1(a64917a33376b7be2998bd4d1c9f349f)
       ember-repl: 8.1.0(97a2ca31a8e4cf9a385bac208eb0c5f1)
       ember-resources: 7.1.0(5417512ae382abcafe5679ee7b1ac481)
-      globby: 16.1.0
+      globby: 16.2.2
       json5: 2.2.3
       package-up: 5.0.0
       reactiveweb: 1.9.1(9f91e21669edde5a0835948ba5900801)
+      rehype-raw: 7.0.0
+      rehype-stringify: 10.0.1
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      repl-sdk: 1.6.0(93d4969b5698d0d4464d33ccc0660007)
       send: 1.2.1
       tracked-built-ins: 4.1.2(@babel/core@7.29.0)
-      typedoc: 0.28.15(typescript@5.9.3)
-      typedoc-plugin-rename-defaults: 0.7.3(typedoc@0.28.15(typescript@5.9.3))
-      unplugin: 2.3.11
+      typedoc: 0.28.16(typescript@5.9.3)
+      typedoc-plugin-rename-defaults: 0.7.3(typedoc@0.28.16(typescript@5.9.3))
+      unist-util-visit: 5.1.0
+      unplugin: 3.3.0(90af3858bcb41b7217b92ee30358691a)
     transitivePeerDependencies:
       - '@babel/core'
       - '@codemirror/lang-css'
       - '@ember/test-helpers'
+      - '@farmfe/core'
       - '@lezer/javascript'
       - '@lezer/lr'
+      - '@rspack/core'
       - bufferutil
+      - bun-types-no-globals
       - encoding
+      - esbuild
+      - rolldown
+      - rollup
       - supports-color
       - typescript
+      - unloader
       - utf-8-validate
+      - vite
+      - webpack
 
   kolorist@1.8.0: {}
 
@@ -21775,12 +21838,12 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typedoc-plugin-rename-defaults@0.7.3(typedoc@0.28.15(typescript@5.9.3)):
+  typedoc-plugin-rename-defaults@0.7.3(typedoc@0.28.16(typescript@5.9.3)):
     dependencies:
       camelcase: 8.0.0
-      typedoc: 0.28.15(typescript@5.9.3)
+      typedoc: 0.28.16(typescript@5.9.3)
 
-  typedoc@0.28.15(typescript@5.9.3):
+  typedoc@0.28.16(typescript@5.9.3):
     dependencies:
       '@gerrit0/mini-shiki': 3.21.0
       lunr: 2.3.9
@@ -21925,6 +21988,16 @@ snapshots:
       acorn: 8.16.0
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
+
+  unplugin@3.3.0(90af3858bcb41b7217b92ee30358691a):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      esbuild: 0.27.2
+      rollup: 4.57.1
+      vite: 8.0.8(a73d90236c2f1639dd2b0f0c483e3bf7)
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -22397,8 +22470,6 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-
-  which-heading-do-i-need@0.2.1: {}
 
   which-heading-do-i-need@0.2.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,7 +472,7 @@ importers:
         version: 7.1.0(5417512ae382abcafe5679ee7b1ac481)
       kolay:
         specifier: github:universal-ember/kolay#dist
-        version: https://codeload.github.com/universal-ember/kolay/tar.gz/954694ac6eac09a27d22b71762f83ecad7080345(0d7798950681c8d6f11c89df9fde55ef)
+        version: https://codeload.github.com/universal-ember/kolay/tar.gz/757d6a0ec85ebe6244c1e8c53a15f3840392536f(0d7798950681c8d6f11c89df9fde55ef)
       limber-ui:
         specifier: workspace:*
         version: link:../../packages/limber-ui
@@ -8274,8 +8274,8 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
 
-  kolay@https://codeload.github.com/universal-ember/kolay/tar.gz/954694ac6eac09a27d22b71762f83ecad7080345:
-    resolution: {gitHosted: true, integrity: sha512-beQHoybQQfO3dbLEc91g+RYoS+1tPhG1QXpElI049GPEeLXVVLf8HWAAD8yHYVbiHoFZPMsn3jiRcqjITd8TwA==, tarball: https://codeload.github.com/universal-ember/kolay/tar.gz/954694ac6eac09a27d22b71762f83ecad7080345}
+  kolay@https://codeload.github.com/universal-ember/kolay/tar.gz/757d6a0ec85ebe6244c1e8c53a15f3840392536f:
+    resolution: {gitHosted: true, integrity: sha512-jMfOl5d8NP0Crjdd7EU/Mn5NCSre99nh87SX56Ze3N9xC2Pj5UTHbDBLH+fRJGdRcUGo5U/kDp6vDJ59eaRnuw==, tarball: https://codeload.github.com/universal-ember/kolay/tar.gz/757d6a0ec85ebe6244c1e8c53a15f3840392536f}
     version: 5.4.0
     engines: {node: '>= 18'}
 
@@ -18832,7 +18832,7 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  kolay@https://codeload.github.com/universal-ember/kolay/tar.gz/954694ac6eac09a27d22b71762f83ecad7080345(0d7798950681c8d6f11c89df9fde55ef):
+  kolay@https://codeload.github.com/universal-ember/kolay/tar.gz/757d6a0ec85ebe6244c1e8c53a15f3840392536f(0d7798950681c8d6f11c89df9fde55ef):
     dependencies:
       '@ember/test-waiters': 4.1.2
       '@embroider/addon-shim': 1.10.2


### PR DESCRIPTION
Previews the unreleased kolay (the plugin rework, universal-ember/kolay#323) on the tutorial app before the release — same mechanism as universal-ember/ember-primitives#794: a root `pnpm.overrides` entry resolves `kolay` to `github:universal-ember/kolay#dist` (the built package contents kolay pushes on every commit to `main`), so `apps/tutorial` keeps its declared range. When kolay releases, the override goes away and the range gets bumped instead.

## Migration (kolay 4.x → next)

- **vite**: `kolay({ src, exclude, onlyDirectories, packages })` → `docs('docs', { src: import.meta.resolve('./public/docs') })`. The manifest is file-based now (each lesson's `prose.md` is the page; the app already normalized `/prose.md` off paths). `import.meta.resolve` is required — a relative `src` produces broken `/@fs` imports (noted on universal-ember/kolay#350).
- **router**: `addRoutes(this, 'docs')` — a scoped mount serving the group from the root URL space, so **all tutorial URLs are unchanged** (`/1-introduction/1-basics`, …).
- **`optimizeDeps.exclude: ['kolay']`**: the scoped-route registry is stateful, so the router and the docs service must share one module instance (kolay's own docs-app does the same).
- **paths**: one `lessonPath()` util maps manifest paths (`/docs/**/prose.md`) to lesson URLs; `selection`, `docs`, `selected`, and `nextPage` go through it.
- **hidden chapters**: the plugin-level `exclude` option is gone. `x-*` chapters were already hidden app-side (`isHidden`, with the `?showHidden` escape hatch); the check is segment-based now so `x-*` *files inside* chapters stay hidden too, and `keyed-each-blocks` keeps its dev-only visibility via `import.meta.env.PROD` in the same place. Net behavior change: hidden chapters are now *routable* by direct URL in prod (they 404'd via manifest-absence before) — their content was always fetchable from `/docs/**` anyway.
- **lesson-only nav**: `onlyDirectories` is gone too, so the stray `.md` notes sitting next to lesson directories (8 of them under `7-form-data/`) would become broken nav entries (no `prompt.gjs`/`prose.md` beneath them). `isHidden` now admits only lesson directories (via their `prose.md`), matching the old manifest exactly: 14 chapters / 68 lessons in prod, +`keyed-each-blocks` in dev.
- **`setupKolay`**: the empty `resolve: {}` option is gone (it's `modules` now).
- **`cssTarget`**: vite 8's default downlevels `light-dark()` into space-toggle vars whose `:root` definitions don't survive chunking, invalidating kolay's colors (found on ember-primitives#794); target browsers that support it natively.

## Depends on

⚠️ **universal-ember/kolay#350** — top-level scoped mounts register as `'application.page'` instead of `'page'` (ember's DSL reports the map root's parent as `'application'`), so the mount is never detected. Verified locally with that fix applied to the resolved dist copy; once #350 merges, `pnpm update kolay` here re-pins dist and this PR goes green.

## Verification

- dev server: root redirect, chapter/lesson select (14 chapters — the 5 `x-*` hidden, `keyed-each-blocks` visible in dev), prev/next navigation, prose + editor + live output all work; URLs identical to production today
- `lint:types` passes; the visitable application test suite passes locally
- prod build: `light-dark()` preserved in CSS; `keyed-each-blocks` hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)
