### PR TITLE
repl-sdk: compile jsx demos with the production JSX runtime

### DIFF
--- a/packages/repl-sdk/src/compilers/react.js
+++ b/packages/repl-sdk/src/compilers/react.js
@@ -18,6 +18,8 @@ export const jsx = {
         return `https://esm.sh/react@19.2.3/es2022/react.development.mjs`;
       case 'react/jsx-dev-runtime':
         return `https://esm.sh/react@19.2.3/es2022/jsx-dev-runtime.development.mjs`;
+      case 'react/jsx-runtime':
+        return `https://esm.sh/react@19.2.3/es2022/jsx-runtime.mjs`;
       case 'react-dom/client':
         return `https://esm.sh/react-dom@19.2.3/es2022/client.development.mjs`;
       case '@babel/standalone':
@@ -37,6 +39,18 @@ export const jsx = {
             [
               babel.availablePresets.react,
               {
+                /**
+                 * The production automatic runtime (jsx/jsxs from
+                 * 'react/jsx-runtime') works under both dev- and
+                 * production-built hosts.
+                 *
+                 * The default (development) transform emits jsxDEV from
+                 * 'react/jsx-dev-runtime', which a production build of react
+                 * deliberately exports as undefined — every compiled demo
+                 * then throws "_jsxDEV is not a function" at evaluation.
+                 */
+                runtime: 'automatic',
+                development: false,
                 // useBuiltIns: true,
               },
             ],

--- a/packages/repl-sdk/tests-browser/tests/jsx/react.test.ts
+++ b/packages/repl-sdk/tests-browser/tests/jsx/react.test.ts
@@ -33,5 +33,29 @@ describe('jsx', () => {
       destroy();
       expect(element.querySelector('h1')).toBeNull();
     });
+
+    test('it renders against a production-built react', async () => {
+      const compiler = new Compiler({
+        resolve: {
+          ...reactModules,
+          // @ts-expect-error Does not provide its own types
+          'react/jsx-runtime': () => import('react/jsx-runtime'),
+          /**
+           * What a *production* build of react exports from this entry: the
+           * dev-only JSX factory is deliberately undefined. Compiling demos
+           * with babel's development JSX transform emits calls to it, so
+           * every demo would throw "_jsxDEV is not a function" against such
+           * a host (dev-built hosts hide this — they ship a real jsxDEV).
+           */
+          'react/jsx-dev-runtime': () => Promise.resolve({ jsxDEV: undefined }),
+        },
+      });
+
+      const { element } = await compiler.compile('jsx', `export default <h1>Hello World</h1>;`, {
+        flavor: 'react',
+      });
+
+      expect(element.querySelector('h1')?.textContent).toContain('Hello World');
+    });
   });
 });


### PR DESCRIPTION
Follow-up to #2201 (that PR merged with only the unmount fix; its title mentioned this one, but the commit never landed).

## The bug

react demos throw `TypeError: _jsxDEV is not a function` at module evaluation whenever the **host app is a production build** — which, in docs apps that render demos inline, takes down the entire page.

babel's react preset defaults to the *development* JSX transform, emitting `jsxDEV` imported from `react/jsx-dev-runtime`. A production build of react deliberately exports `jsxDEV` as `undefined` from that entry, so every compiled demo blows up. Development-built hosts hide it — they ship a real `jsxDEV` — so it only surfaces in deployed previews/production.

## The fix

Compile with the production automatic runtime (`jsx`/`jsxs` from `react/jsx-runtime`), which works under **both** dev- and production-built hosts, and add `react/jsx-runtime` to the compiler's fallback resolve map alongside the existing dev-runtime entry.

## Verification

Found in AuditBoard's kolay-based docs app: before, every production page containing a react demo failed to load; after, the Form page renders all 13 demos (3 of them react) with zero console errors.

**Tests**: added `it renders against a production-built react` to the react browser test — it supplies `react/jsx-dev-runtime` exporting `jsxDEV: undefined` (exactly what a production react does) and asserts the demo still renders. Verified it fails with precisely the production error (`TypeError: _jsxDEV is not a function`) when the source fix is reverted.

- repl-sdk node tests: 56 passing
- repl-sdk browser tests (chrome): 22 passing, 3 pre-existing skips
- `pnpm lint` is clean apart from a pre-existing `ember-repl#lint:types` failure that reproduces on unmodified `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
