### PR TITLE
ember-repl: publish a caret range for repl-sdk

### DIFF
--- a/packages/ember-repl/package.json
+++ b/packages/ember-repl/package.json
@@ -49,7 +49,7 @@
     "ember-primitives": "^0.61.1",
     "ember-resolver": "^13.1.0",
     "ember-resources": "^7.1.0",
-    "repl-sdk": "workspace:*"
+    "repl-sdk": "workspace:^"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -916,7 +916,7 @@ importers:
         specifier: ^7.1.0
         version: 7.1.0(5417512ae382abcafe5679ee7b1ac481)
       repl-sdk:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../repl-sdk
     devDependencies:
       '@arethetypeswrong/cli':


### PR DESCRIPTION
`workspace:*` publishes as an **exact** version, so ember-repl 8.0.2 shipped with `"repl-sdk": "1.5.2"` rather than a range.

The practical cost: consumers can't pick up a repl-sdk patch release — including fixes to the very compilers they're already running — without waiting for a new ember-repl release. Hitting the react-demo fixes in repl-sdk 1.6.1 (#2201, #2202) currently requires upgrading to ember-repl 8.2.0, which also pulls `ember-primitives ^0.61.1`; for an app pinned to an older ember-primitives that's a much larger upgrade than the patch it actually wants. An app that additionally depends on repl-sdk directly ends up with two copies.

`workspace:^` publishes as `^<version>`, which is how several other workspace deps in this repo are already declared.

**Tests**: repl-sdk node suite 56/56 after re-resolving the lockfile; the change is limited to `packages/ember-repl/package.json` plus the resulting lockfile line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
