### PR TITLE
fix(ember-repl): add missing embroider v1 addon-main.cjs shim

### DIFF
--- a/packages/ember-repl/addon-main.cjs
+++ b/packages/ember-repl/addon-main.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+const { addonV1Shim } = require('@embroider/addon-shim');
+
+module.exports = addonV1Shim(__dirname);

--- a/packages/ember-repl/package.json
+++ b/packages/ember-repl/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "author": "NullVoxPopuli",
   "files": [
+    "addon-main.cjs",
     "declarations",
     "dist",
     "src"
@@ -43,6 +44,7 @@
   "dependencies": {
     "@ember/test-helpers": "^5.4.1",
     "@ember/test-waiters": "^4.1.0",
+    "@embroider/addon-shim": "1.10.2",
     "codemirror": "^6.0.2",
     "content-tag": "^4.0.0",
     "decorator-transforms": "2.3.1",
@@ -127,7 +129,8 @@
   },
   "ember-addon": {
     "version": 2,
-    "type": "addon"
+    "type": "addon",
+    "main": "addon-main.cjs"
   },
   "imports": {
     "#src/*": "./src/*",
@@ -141,7 +144,8 @@
     "./test-support": {
       "types": "./declarations/test-support.d.ts",
       "default": "./dist/test-support.js"
-    }
+    },
+    "./addon-main.js": "./addon-main.cjs"
   },
   "typesVersions": {
     "*": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -897,6 +897,9 @@ importers:
       '@ember/test-waiters':
         specifier: ^4.1.0
         version: 4.1.2
+      '@embroider/addon-shim':
+        specifier: 1.10.2
+        version: 1.10.2
       codemirror:
         specifier: ^6.0.2
         version: 6.0.2
@@ -12687,10 +12690,10 @@ snapshots:
 
   '@embroider/addon-shim@1.10.2':
     dependencies:
-      '@embroider/shared-internals': 3.0.2
+      '@embroider/shared-internals': 3.1.1
       broccoli-funnel: 3.0.8
       common-ancestor-path: 1.0.1
-      semver: 7.8.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15826,7 +15829,7 @@ snapshots:
       caniuse-lite: 1.0.30001788
       isbot: 3.8.0
       object-path: 0.11.8
-      semver: 7.8.1
+      semver: 7.8.5
       ua-parser-js: 1.0.41
 
   browserslist-to-esbuild@2.1.1(browserslist@4.28.2):
@@ -17009,7 +17012,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.2
       '@ember/test-waiters': 4.1.2
-      '@embroider/addon-shim': 1.10.3
+      '@embroider/addon-shim': 1.10.2
       '@embroider/macros': 1.20.5(c8332dc3f90c0e60eb130a3a85f980b9)
       '@floating-ui/dom': 1.7.5
       '@glimmer/component': 2.1.1
@@ -21723,7 +21726,7 @@ snapshots:
 
   tracked-toolbox@2.2.0(@babel/core@7.29.0):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
+      '@embroider/addon-shim': 1.10.2
       decorator-transforms: 2.4.0(@babel/core@7.29.0)
       ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.29.0)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

`ember-repl` is declared as an `ember-addon` (v2) but doesn't ship an
`addon-main.cjs` v1 shim, unlike its sibling package `limber-ui` in this
monorepo. Consumers that go through `@embroider/compat` (classic ember-cli
apps, or vite apps using `compatPrebuild` for legacy addon resolution)
fail to discover/build `ember-repl` as an addon without this shim.

## Changes

Mirrors the exact wiring `limber-ui` already has:

- `addon-main.cjs` using `@embroider/addon-shim`'s `addonV1Shim`
- `package.json`: `files` includes `addon-main.cjs`, `ember-addon.main`
  points at it, an `./addon-main.js` exports subpath, and
  `@embroider/addon-shim` added as a dependency (pinned to `1.10.2`,
  matching `limber-ui`'s pin)

We're carrying this as a `pnpm patch` in downstream consumer
[carbon-components-ember](https://github.com/carbon-design-system/carbon-components-ember).

## Test plan

- [x] `pnpm lint:js` passes
- [x] `pnpm build` succeeds and `dist/` + `addon-main.cjs` are present
- [x] `pnpm lint:package` (publint) passes