### PR TITLE
fix(repl-sdk): support boolean ShadowComponent + style-isolate shadow-DOM demos

### DIFF
--- a/packages/repl-sdk/src/compilers/ember/gmd.js
+++ b/packages/repl-sdk/src/compilers/ember/gmd.js
@@ -12,7 +12,7 @@ let elementId = 0;
  *   scope: Record<string, unknown>,
  *   remarkPlugins: Plugin[],
  *   rehypePlugins: Plugin[],
- *   ShadowComponent: string | undefined,
+ *   ShadowComponent: string | boolean | undefined,
  *   CopyComponent: string | undefined
  *   owner?: unknown | undefined
  *   }}
@@ -33,9 +33,37 @@ export function filterOptions(options) {
     scope: /** @type {Record<string, unknown>}*/ (options?.scope || {}),
     remarkPlugins: /** @type {Plugin[]}*/ (options?.remarkPlugins || []),
     rehypePlugins: /** @type {Plugin[]}*/ (options?.rehypePlugins || []),
-    ShadowComponent: /** @type {string}*/ (options?.ShadowComponent),
+    // Historically this was a component *name* to be resolved and used to
+    // wrap each live demo's invocation before it was ever rendered. Now that
+    // live demos are compiled+rendered independently and grafted into a
+    // placeholder element (see the `render` loop below), there's no longer a
+    // component-invocation step to wrap - so any truthy value (boolean or
+    // the legacy string) just turns on native shadow-DOM wrapping instead.
+    ShadowComponent: /** @type {string | boolean}*/ (options?.ShadowComponent),
     CopyComponent: /** @type {string}*/ (options?.CopyComponent),
   };
+}
+
+/**
+ * Mirrors ember-primitives' `<Shadowed includeStyles>` component: attaches
+ * an open shadow root to `target` and re-imports every stylesheet `<link>`
+ * currently in the document so the shadow-rendered demo still picks up the
+ * app's styles despite being style-isolated from it.
+ *
+ * @param {Element} target
+ * @returns {ShadowRoot}
+ */
+function attachStyledShadowRoot(target) {
+  const shadowRoot = target.attachShadow({ mode: 'open' });
+  const style = document.createElement('style');
+
+  style.textContent = [...document.querySelectorAll('link[rel="stylesheet"]')]
+    .map((link) => `@import "${/** @type {HTMLLinkElement} */ (link).href}";`)
+    .join('\n');
+
+  shadowRoot.appendChild(style);
+
+  return shadowRoot;
 }
 
 /**
@@ -159,7 +187,17 @@ export async function compiler(config, api) {
           );
 
           destroyables.push(subRender.destroy);
-          target.appendChild(subRender.element);
+
+          const meta = /** @type {string | undefined} */ (infoObj.meta);
+          const optedOut = Boolean(meta && meta.includes('no-shadow'));
+
+          if (userOptions.ShadowComponent && !optedOut) {
+            const shadowRoot = attachStyledShadowRoot(target);
+
+            shadowRoot.appendChild(subRender.element);
+          } else {
+            target.appendChild(subRender.element);
+          }
         })
       );
 


### PR DESCRIPTION
## Summary

`ShadowComponent` used to name a component to resolve and wrap each live
demo's invocation in, before ember-repl's 8.x rewrite made compilation and
rendering independent steps grafted into a placeholder element — at which
point there was no invocation left to wrap, so passing `ShadowComponent`
silently did nothing. This dropped the shadow-DOM style isolation for live
demos that ember-repl 6.x used to provide by default.

## Changes

- `filterOptions` accepts `ShadowComponent: string | boolean`.
- When `ShadowComponent` is truthy, the gmd compiler's `render` now attaches
  an open shadow root around each live demo's rendered element via a new
  `attachStyledShadowRoot` helper, which re-imports the document's
  stylesheets into the shadow root (mirroring ember-primitives'
  `<Shadowed includeStyles>` component) so the isolated demo still picks up
  the host app's styles.
- Individual code fences can opt out of the wrapping with a `no-shadow` meta
  flag on the fence.

We're carrying this as a `pnpm patch` in downstream consumer
[carbon-components-ember](https://github.com/carbon-design-system/carbon-components-ember),
along with a companion change in `kolay` that sets `ShadowComponent: true`
by default for gmd compilation.

## Test plan

- [x] `pnpm lint:js` / `pnpm lint:prettier` pass
- [x] `pnpm test:node` — 52/52 relevant tests pass (one pre-existing,
      unrelated failure from a missing optional `codemirror-lang-glimmer-js`
      dependency in this sandbox, unrelated to `gmd.js`)