### PR TITLE
fix(repl-sdk): give each gmd island its own owner, like gjs/hbs already do

### DIFF
--- a/packages/ember-repl/tests/rendering/compile-markdown-test.gts
+++ b/packages/ember-repl/tests/rendering/compile-markdown-test.gts
@@ -206,6 +206,55 @@ module('Rendering | compile()', function (hooks) {
       assert.dom().hasText(text);
     });
 
+    test('a singleton scope component renders in more than one document', async function (assert) {
+      // Each document renders as its own island with its own program
+      // artifacts, but a component's template (and its compiled handle) is
+      // cached per owner — so the islands must not share an owner, or the
+      // second document dies with
+      // "Cannot read properties of null (reading 'syscall')".
+      const LocalComponent = <template>a singleton component</template>;
+
+      setupOnerror((e) => {
+        console.error(e);
+        assert.notOk('This should not error');
+      });
+
+      const compiler = getCompiler(this);
+
+      for (const heading of ['first', 'second']) {
+        const snippet = stripIndent`
+          # ${heading}
+
+          <LocalComponent />
+        `;
+
+        let component: ComponentLike | undefined;
+
+        const state = compile(compiler, snippet, {
+          format: 'glimdown',
+          onSuccess: (comp) => (component = comp),
+          onError: unexpectedErrorHandler,
+          onCompileStart: () => {
+            /* not used */
+          },
+
+          // @ts-ignore
+          scope: {
+            LocalComponent,
+          },
+        });
+
+        await state.promise;
+
+        debugAssert(`[BUG]`, component);
+
+        await render(component);
+
+        assert.dom('h1').hasText(heading);
+        assert.dom().containsText('a singleton component');
+      }
+    });
+
     test('adding to top-level scope applies to rendered "hbs" codefences', async function (assert) {
       const text = `This is a local component added to scope`;
       const LocalComponent = <template>{{text}}</template>;

--- a/packages/repl-sdk/src/compilers/ember/gmd.js
+++ b/packages/repl-sdk/src/compilers/ember/gmd.js
@@ -3,6 +3,7 @@
  */
 import { assert, isRecord } from '../../utils.js';
 import { buildCodeFenceMetaUtils } from '../markdown/utils.js';
+import { makeOwner } from './owner.js';
 
 let elementId = 0;
 
@@ -104,9 +105,15 @@ export async function compiler(config, api) {
           : undefined
       );
 
+      // A fresh owner per render, like gjs/hbs do: template instances (and
+      // their compiled handles) are cached per owner, but each renderComponent
+      // call has its own program artifacts — sharing one owner across islands
+      // would make glimmer reuse a compiled handle from another island's
+      // program, blowing up with "Cannot read properties of null (reading
+      // 'syscall')" the second time a singleton scope component is invoked.
       const result = renderComponent(compiled, {
         into: element,
-        owner: userOptions.owner,
+        owner: makeOwner(userOptions.owner),
         ...(args ? { args } : {}),
       });
 


### PR DESCRIPTION
The glimdown renderer passed the shared compiler-level owner to every `renderComponent` island, while `gjs` and `hbs` islands already create a fresh `makeOwner()` delegate per render. Template instances are cached per owner, and each `renderComponent` call has its own program artifacts — so on ember-source 6.x (where a compilable's compiled handle is cached once, not per compilation context), the second island to invoke the same singleton scope component reused a handle from another island's program and crashed with:

```
TypeError: Cannot read properties of null (reading 'syscall')
    at AppendOpcodes.evaluate
```

ember-source 7.3+ keys the compiled-handle cache by compilation context, so this repo's own suite can't reproduce the crash — the new test documents the scenario and passes either way here. Hosts on ember-source 6.x hit it as soon as a glimdown document renders a singleton scope component on two pages; universal-ember/kolay's `wrap-demo` work found it (kolay carries a temporary pnpm patch for repl-sdk 1.5.2 with this same fix, dropped once this ships through repl-sdk → ember-repl).

- `gmd` render now uses `makeOwner(userOptions.owner)` per island, matching `gjs`/`hbs`
- regression test: a singleton scope component rendered across two glimdown documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)