### PR TITLE
fix(repl-sdk): correct the whitespace escape in formatDefaultId

### DIFF
--- a/packages/repl-sdk/src/compilers/markdown/heading-id.js
+++ b/packages/repl-sdk/src/compilers/markdown/heading-id.js
@@ -38,7 +38,7 @@ function extractText(children) {
  * @param {string} value
  */
 function formatDefaultId(value) {
-  return kebabCase(value.replaceAll(/\\s+/g, ' ').trim());
+  return kebabCase(value.replaceAll(/\s+/g, ' ').trim());
 }
 
 /**

--- a/packages/repl-sdk/src/compilers/markdown/parse.test.ts
+++ b/packages/repl-sdk/src/compilers/markdown/parse.test.ts
@@ -237,6 +237,24 @@ describe('default features', () => {
   });
 });
 
+describe('heading ids', () => {
+  it('collapses runs of whitespace in the heading text', async () => {
+    const result = await parseMarkdown(`##   Hello    World  `, { ...defaults });
+
+    // Only the id is normalized; the rendered text keeps the author's spacing.
+    expect(result.text).toContain('id="hello-world"');
+  });
+
+  it('treats a literal \\s in a heading as text, not as whitespace', async () => {
+    // The regex in formatDefaultId used to be /\\s+/g -- a literal backslash
+    // followed by `s`, rather than whitespace -- so `\s` here was replaced with
+    // a space and the `s` vanished from the id.
+    const result = await parseMarkdown(`## a \\s b`, { ...defaults });
+
+    expect(result.text).toContain('id="a-s-b"');
+  });
+});
+
 describe('options', () => {
   describe('remarkPlugins', () => {
     it('works', async () => {


### PR DESCRIPTION
Draft — tiny one, happy to close if you'd rather handle it differently.

`formatDefaultId` in `packages/repl-sdk/src/compilers/markdown/heading-id.js` reads:

```js
return kebabCase(value.replaceAll(/\\s+/g, ' ').trim());
```

`/\\s+/g` matches a literal backslash followed by one or more `s`, not whitespace. The intent looks like collapsing runs of whitespace before kebab-casing.

**Mostly a no-op.** `kebabCase` already splits on whitespace, so realistic headings slug identically either way. The observable difference is a heading containing a literal `\s`, where the `s` got eaten:

```
## a \s b     before: id="a-b"     after: id="a-s-b"
```

## Tests

Two cases in `parse.test.ts`:

- runs of whitespace collapse to a single `-` — passes either way, pinning the intent so a future refactor of `formatDefaultId` can't quietly change it
- a literal `\s` is text, not whitespace — the actual regression test

I verified the second genuinely fails without the fix (`expected '<h2 id="a-b">a \s b</h2>' to contain 'id="a-s-b"'`) rather than just passing alongside it.

```
Tests  21 passed (21)     # packages/repl-sdk parse.test.ts
```

Full `repl-sdk` suite is unchanged otherwise: 1 test file (`compilers.ember.onUnhandled.test.ts`) fails to load and `lint:types` reports 3 errors, both identical on clean `main` in my checkout.

No README change — this doesn't alter documented behavior.

## Alternative

Two reasonable outcomes and I don't have a strong preference:

1. This PR — fix the escape, keep the call.
2. Drop the `replaceAll` entirely, since `kebabCase` makes it redundant. (Note this would change the `\s` case again, to `a-s-b` as well — same result, one fewer moving part.)

> [!NOTE]
> Related but independent: https://github.com/NullVoxPopuli/limber/pull/2216 adds a configurable heading slugger, which needs whitespace actually collapsed — a space-to-dash slugger emits `hello--there` without it. It normalizes at a different call site, so the two don't conflict and either can merge first.

---
🤖 Drafted by Claude (Opus 5) for @gitKrystan, while tracking down why heading anchors differed between our docs site and GitHub (soxhub/auditboard-frontend#42085).
