### PR TITLE
fix(repl-sdk): make {#custom-id} heading suffix actually set the id

### DIFF
--- a/packages/repl-sdk/src/compilers/markdown/heading-id.js
+++ b/packages/repl-sdk/src/compilers/markdown/heading-id.js
@@ -63,9 +63,11 @@ export function headingId(options = { defaults: false }) {
       if (lastChild && lastChild.type === 'text') {
         const string = lastChild.value.replace(/ +$/, '');
         const matched = string.match(/ {#([^]+?)}$/);
+        const suffix = matched?.[0];
+        const customId = matched?.[1];
 
-        if (matched) {
-          const remaining = string.slice(0, -matched[0].length);
+        if (suffix && customId) {
+          const remaining = string.slice(0, -suffix.length);
 
           if (remaining) {
             lastChild.value = remaining;
@@ -73,7 +75,7 @@ export function headingId(options = { defaults: false }) {
             node.children.pop();
           }
 
-          setNodeId(node, matched[1]);
+          setNodeId(node, customId);
 
           return;
         }

--- a/packages/repl-sdk/src/compilers/markdown/heading-id.js
+++ b/packages/repl-sdk/src/compilers/markdown/heading-id.js
@@ -65,6 +65,16 @@ export function headingId(options = { defaults: false }) {
         const matched = string.match(/ {#([^]+?)}$/);
 
         if (matched) {
+          const remaining = string.slice(0, -matched[0].length);
+
+          if (remaining) {
+            lastChild.value = remaining;
+          } else {
+            node.children.pop();
+          }
+
+          setNodeId(node, matched[1]);
+
           return;
         }
       }

--- a/packages/repl-sdk/src/compilers/markdown/parse.test.ts
+++ b/packages/repl-sdk/src/compilers/markdown/parse.test.ts
@@ -253,6 +253,20 @@ describe('heading ids', () => {
 
     expect(result.text).toContain('id="a-s-b"');
   });
+
+  it('uses a {#custom-id} suffix as the id and strips it from the text', async () => {
+    const result = await parseMarkdown(`## A very long heading {#short-id}`, { ...defaults });
+
+    expect(result.text).toBe('<h2 id="short-id">A very long heading</h2>');
+  });
+
+  it('supports {#custom-id} on a heading ending in formatting', async () => {
+    const result = await parseMarkdown(`## Use \`parseMarkdown\` here {#parse}`, {
+      ...defaults,
+    });
+
+    expect(result.text).toBe('<h2 id="parse">Use <code>parseMarkdown</code> here</h2>');
+  });
 });
 
 describe('options', () => {


### PR DESCRIPTION
`{#custom-id}` now works as documented: the suffix becomes the heading id and is stripped from the rendered text.

Before, the suffix only suppressed the auto id. Nothing assigned the custom one, and the literal `{#custom-id}` stayed visible in the heading, even though kolay documents the feature as "To choose the id yourself, add `{#custom-id}` at the end of the heading".

```md
## A very long heading {#short-id}
```

before: `<h2>A very long heading {#short-id}</h2>` (no id at all)
after: `<h2 id="short-id">A very long heading</h2>`

Independent of #2216 and survives its rework: this branch of `headingId` is the one piece that stays custom once auto ids move to rehype-slug, since rehype-slug skips headings that already carry an id.

Tests: 2 added in `parse.test.ts` (plain suffix; suffix after inline code). 60/60 across repl-sdk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
